### PR TITLE
build: establish lint rule infrastructure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  harness:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Test repository tooling
+        run: python3 -m unittest discover -s tests/harness -v
+      - name: Validate and generate rule configuration
+        run: python3 tools/build_config.py --output build/.clang-tidy
+
+  declarative-rules:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install LLVM 23 clang-tidy
+        run: |
+          wget -q https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 23
+          sudo apt-get install -y clang-tidy-23
+          clang-tidy-23 --version
+      - name: Test declarative rules
+        run: python3 tools/test_rules.py --clang-tidy clang-tidy-23

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build/
+__pycache__/
+*.pyc

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,47 @@
+# Contributing
+
+`qt-kde-lint` is intended to turn repeated Qt/KDE mistakes into precise, testable diagnostics without duplicating checks already provided by the compiler, clang-tidy, or Clazy.
+
+## Before adding a rule
+
+1. Confirm the pattern represents a real defect or high-value maintainability problem rather than merely a personal style preference.
+2. Search existing clang-tidy and Clazy checks first.
+3. Reduce the problem to a minimal bad example and at least one close correct example.
+4. Prefer a declarative query-based clang-tidy check when it can express the rule precisely.
+5. Do not broaden a matcher merely to catch more examples if that creates credible false positives.
+
+## Pull request scope
+
+A new lint rule should normally be one pull request containing:
+
+- `rules/<rule-name>.json`;
+- `tests/<rule-name>/bad.cpp`;
+- `tests/<rule-name>/good.cpp`;
+- documentation or evidence where useful.
+
+Infrastructure, documentation, and CI work may be grouped separately.
+
+## Diagnostics
+
+Diagnostics should be useful without prior knowledge of this repository. Prefer wording that answers:
+
+- what is wrong;
+- why it matters in Qt/KDE code;
+- what repair is normally appropriate.
+
+Avoid diagnostics that only restate a style preference or assume the reader already knows the rule.
+
+## Testing
+
+Run:
+
+```sh
+python3 tools/build_config.py --output build/.clang-tidy
+python3 tools/test_rules.py --clang-tidy clang-tidy-23
+```
+
+Every rule must have a triggering and non-triggering fixture. Additional fixtures are encouraged when a matcher has important boundaries.
+
+## Upstreaming
+
+If a rule proves generally applicable to Qt code rather than being specific to this project's corpus, consider proposing it to Clazy or clang-tidy. The local rule may remain as an incubator until upstream support is available in the toolchain used by consumers.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,54 @@
 # qt-kde-lint
 
-Experimental lint rules for Qt and KDE C++ applications, with an initial focus on catching recurring mistakes produced by LLM-assisted development before they consume another review/fix iteration.
+Lint rules for Qt and KDE applications, initially focused on catching recurring mistakes introduced by LLM-assisted development before they require another review/fix iteration.
 
-The project is intended to complement, not replace, existing tooling such as `clang-tidy` and Clazy. Rules should prefer existing checks where they already cover the problem, use declarative clang-tidy custom checks where practical, and only introduce compiled checks when the rule genuinely requires them.
+The project complements existing static analysis rather than replacing it:
+
+1. use compiler diagnostics and existing `clang-tidy` checks;
+2. use Clazy for established Qt-specific checks;
+3. add a `qt-kde-lint` declarative check only when the problem is not already covered;
+4. add a compiled clang-tidy/Clazy-style check only when a declarative AST matcher is insufficient.
+
+The first implementation target is LLVM 23's experimental query-based clang-tidy custom checks. This keeps most project-specific rules as data rather than another C++ linter binary.
+
+## Rule policy
+
+Rules are intentionally high precision. A missed instance is preferable to a noisy rule that teaches humans or coding agents to ignore the linter.
+
+Each new rule should normally be introduced in its own pull request and include:
+
+- evidence or motivation for the recurring problem;
+- a stable rule name;
+- a diagnostic that explains the problem, consequence, and repair direction;
+- at least one example that must trigger;
+- at least one nearby/correct example that must not trigger;
+- a note when an existing Clazy or clang-tidy check was considered and found insufficient.
+
+See [`docs/RULE_AUTHORING.md`](docs/RULE_AUTHORING.md) for the contract.
+
+## Layout
+
+- `rules/` — declarative custom-check definitions, one JSON file per rule. JSON is used because it can be validated with Python's standard library and emitted as YAML-compatible clang-tidy configuration.
+- `tests/<rule-name>/` — positive and negative regression fixtures for each rule.
+- `tools/build_config.py` — validates rules and generates a clang-tidy configuration.
+- `tools/test_rules.py` — runs every rule's regression fixtures.
+- `docs/` — architecture and rule-authoring rationale.
+
+## Local development
+
+LLVM/clang-tidy 23 or newer with query-based custom checks enabled is required.
+
+```sh
+python3 tools/build_config.py --output build/.clang-tidy
+python3 tools/test_rules.py --clang-tidy clang-tidy-23
+```
+
+Query-based custom checks currently require `--experimental-custom-checks`. The CI workflow pins the intended clang-tidy major rather than relying on the GitHub runner default.
 
 ## Status
 
-Repository bootstrap in progress. Rules will be introduced incrementally, normally one rule per pull request with positive and negative regression tests and diagnostics written to be useful to both humans and coding agents.
+The repository is being built incrementally. Infrastructure changes may share a PR, but actual lint rules should normally remain one rule per PR so their evidence, tests, false-positive tradeoffs, and history stay independently reviewable.
+
+## License
+
+A project license has not yet been selected. This is being left explicit rather than inferring a license from other repositories which use differing licenses.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,47 @@
+# Architecture
+
+## Goal
+
+Catch predictable Qt/KDE defects early, especially recurring mistakes from coding agents, while retaining the parsers, AST, compile database support, suppression mechanisms, and ecosystem integration already provided by Clang tooling.
+
+## Analysis layers
+
+`qt-kde-lint` assumes a layered analysis stack:
+
+1. compiler warnings;
+2. built-in clang-tidy checks;
+3. Clazy checks for established Qt semantics;
+4. declarative `qt-kde-lint` checks;
+5. compiled custom checks only where the previous layers cannot express the rule precisely.
+
+A new rule should live at the lowest existing layer that can implement it accurately. Duplication is a maintenance cost and usually produces conflicting diagnostics.
+
+## Declarative rules
+
+LLVM 23 introduced experimental query-based clang-tidy custom checks. They are based on clang-query/AST matcher syntax and can emit warnings and associated notes. They deliberately do not target complex analysis or fix-its.
+
+This is the preferred implementation for local rules because it keeps each check reviewable as a small data file and avoids maintaining another Clang-based executable.
+
+The upstream feature is experimental, so this repository pins a tested LLVM major and keeps rule definitions isolated from the generated clang-tidy configuration. If LLVM changes the configuration schema, the generator can adapt without rewriting the evidence and test layout for every rule.
+
+## Rule definition format
+
+Each `rules/*.json` file is one object corresponding to an entry in clang-tidy's `CustomChecks` array. Required fields are:
+
+- `Name` — must begin with `qt-kde-lint-`;
+- `Query` — clang-query text containing a `match` expression;
+- `Diagnostic` — one or more bound-node diagnostics, including at least one warning.
+
+The generated clang-tidy check name is `custom-<Name>`.
+
+JSON is intentional: it is a strict, dependency-free authoring subset that can be loaded and validated by Python's standard library. The generated top-level configuration is also emitted as JSON, which LLVM's YAML configuration parser accepts.
+
+## Compiled rules
+
+A compiled extension should be introduced only with a concrete example that requires capabilities such as control-flow reasoning, preprocessing callbacks, substantial cross-node state, or fix-its that cannot be represented by a query-based check.
+
+Compiled checks should remain out-of-tree unless/until an upstream destination is appropriate.
+
+## Non-C++ rules
+
+Qt/KDE projects also contain CMake, QML, desktop files, AppStream metadata, DBus XML, KConfig data, and CI configuration. These should not be forced through clang-tidy. If recurring mistakes are found there, this repository may gain thin format-specific rule runners while retaining the same principles: stable rule IDs, high precision, explanatory diagnostics, and positive/negative regression tests.

--- a/docs/RULE_AUTHORING.md
+++ b/docs/RULE_AUTHORING.md
@@ -1,0 +1,80 @@
+# Rule authoring contract
+
+Every rule should be understandable as an independent review unit.
+
+## Naming
+
+Rule definitions use a stable `Name` beginning with `qt-kde-lint-`, for example:
+
+```text
+qt-kde-lint-qobject-parent
+```
+
+clang-tidy exposes query-based checks with the `custom-` module prefix, so the emitted check name is:
+
+```text
+custom-qt-kde-lint-qobject-parent
+```
+
+Do not rename a published rule merely to improve wording. A stable diagnostic identifier is useful to CI suppressions, documentation, humans, and coding agents.
+
+## Definition
+
+A rule file is `rules/<Name>.json` with the shape:
+
+```json
+{
+  "Name": "qt-kde-lint-example",
+  "Query": "match ...",
+  "Diagnostic": [
+    {
+      "BindName": "problem",
+      "Message": "Explain what is wrong, why it matters, and the usual repair direction.",
+      "Level": "Warning"
+    }
+  ]
+}
+```
+
+Additional `Note` diagnostics are encouraged when pointing at a related declaration or ownership/lifetime participant materially improves the explanation.
+
+## Required tests
+
+Each rule gets `tests/<Name>/` containing at minimum:
+
+- `bad.cpp` — must emit `[custom-<Name>]`;
+- `good.cpp` — must not emit that diagnostic.
+
+Use minimal local type declarations where possible instead of making the regression suite depend on a complete Qt/KDE SDK. The matcher should rely on semantic properties represented in the AST rather than filesystem-specific header paths whenever practical.
+
+If one bad/good pair does not describe an important boundary, add numbered fixtures (`bad-2.cpp`, `good-2.cpp`, etc.).
+
+## Evidence
+
+A rule PR should link or describe the defects that motivated it. When mining generated pull requests, preserve enough information to answer:
+
+- what the generated code did;
+- what review or subsequent correction showed was wrong;
+- whether the problem occurred more than once;
+- whether an existing checker already catches it;
+- what false-positive cases were considered.
+
+A rule may be valuable after one occurrence when the defect is severe and the matcher is unambiguous, but recurrence is stronger evidence.
+
+## Diagnostic quality
+
+Diagnostics are part of the product. They should generally contain:
+
+1. the problematic construct;
+2. the Qt/KDE consequence or risk;
+3. the usual direction for correction.
+
+They should not demand a mechanically specific fix when multiple ownership, threading, lifetime, or API designs may be valid.
+
+## Precision policy
+
+Prefer precision over recall. Do not merge a rule with obvious false positives merely because it catches a common generated pattern. Narrow it, split it into multiple rules, or leave it as review guidance until static analysis can express it safely.
+
+## Existing-tool check
+
+Before merging, compare against current clang-tidy and Clazy checks. If an existing rule catches the same defect with comparable precision and diagnostics, enable or document that rule rather than adding a duplicate here.

--- a/rules/README.md
+++ b/rules/README.md
@@ -1,0 +1,7 @@
+# Declarative rules
+
+Each `*.json` file in this directory is one LLVM query-based custom clang-tidy check definition.
+
+Rules must follow [`docs/RULE_AUTHORING.md`](../docs/RULE_AUTHORING.md). In particular, the filename must exactly match the rule's `Name`, names begin with `qt-kde-lint-`, and every rule must have positive and negative regression fixtures under `tests/<Name>/`.
+
+Do not add a local rule when current clang-tidy or Clazy already provides materially equivalent coverage.

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,14 @@
+# Regression tests
+
+Declarative rule fixtures live in `tests/<rule-name>/`.
+
+At minimum every rule must contain:
+
+- `bad.cpp`, which emits `[custom-<rule-name>]`;
+- `good.cpp`, which does not emit that diagnostic.
+
+Additional `bad-*.cpp` and `good-*.cpp` fixtures are automatically included by the test runner.
+
+Shared lightweight declarations that model Qt/KDE types without requiring the full SDK may live in `tests/include/`. They should model only the semantics required by the AST matcher and should not be mistaken for API compatibility shims.
+
+`tests/harness/` contains tests for the repository's own rule/config tooling rather than lint rules.

--- a/tests/harness/test_build_config.py
+++ b/tests/harness/test_build_config.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "tools"))
+
+from build_config import RuleError, build_config, load_rules  # noqa: E402
+
+
+class BuildConfigTests(unittest.TestCase):
+    def write_rule(self, directory: Path, name: str, **overrides: object) -> Path:
+        rule = {
+            "Name": name,
+            "Query": 'match functionDecl().bind("problem")',
+            "Diagnostic": [
+                {
+                    "BindName": "problem",
+                    "Message": "example diagnostic",
+                    "Level": "Warning",
+                }
+            ],
+        }
+        rule.update(overrides)
+        path = directory / f"{name}.json"
+        path.write_text(json.dumps(rule), encoding="utf-8")
+        return path
+
+    def test_builds_custom_check_glob(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            directory = Path(temp)
+            self.write_rule(directory, "qt-kde-lint-example")
+            rules = load_rules(directory.glob("*.json"))
+            config = build_config(rules)
+            self.assertEqual(config["Checks"], "-*,custom-qt-kde-lint-*")
+            self.assertEqual(config["CustomChecks"][0]["Name"], "qt-kde-lint-example")
+
+    def test_requires_warning(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            directory = Path(temp)
+            name = "qt-kde-lint-example"
+            self.write_rule(
+                directory,
+                name,
+                Diagnostic=[
+                    {
+                        "BindName": "problem",
+                        "Message": "only a note",
+                        "Level": "Note",
+                    }
+                ],
+            )
+            with self.assertRaisesRegex(RuleError, "at least one diagnostic"):
+                load_rules(directory.glob("*.json"))
+
+    def test_requires_filename_to_match_name(self) -> None:
+        with tempfile.TemporaryDirectory() as temp:
+            directory = Path(temp)
+            path = self.write_rule(directory, "qt-kde-lint-example")
+            path.rename(directory / "wrong-name.json")
+            with self.assertRaisesRegex(RuleError, "filename must match"):
+                load_rules(directory.glob("*.json"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/build_config.py
+++ b/tools/build_config.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Validate rule definitions and emit one clang-tidy configuration."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Iterable
+
+PREFIX = "qt-kde-lint-"
+
+
+class RuleError(ValueError):
+    pass
+
+
+def load_rules(paths: Iterable[Path]) -> list[dict]:
+    rules: list[dict] = []
+    names: set[str] = set()
+
+    for path in sorted(paths):
+        try:
+            rule = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise RuleError(f"{path}: cannot load rule: {exc}") from exc
+
+        if not isinstance(rule, dict):
+            raise RuleError(f"{path}: rule must be a JSON object")
+
+        name = rule.get("Name")
+        query = rule.get("Query")
+        diagnostics = rule.get("Diagnostic")
+
+        if not isinstance(name, str) or not name.startswith(PREFIX):
+            raise RuleError(f"{path}: Name must begin with {PREFIX!r}")
+        if path.stem != name:
+            raise RuleError(f"{path}: filename must match Name ({name}.json)")
+        if name in names:
+            raise RuleError(f"{path}: duplicate rule name {name}")
+        names.add(name)
+
+        if not isinstance(query, str) or "match" not in query:
+            raise RuleError(f"{path}: Query must be a non-empty clang-query match expression")
+        if not isinstance(diagnostics, list) or not diagnostics:
+            raise RuleError(f"{path}: Diagnostic must be a non-empty list")
+
+        warning_count = 0
+        for index, diagnostic in enumerate(diagnostics):
+            if not isinstance(diagnostic, dict):
+                raise RuleError(f"{path}: Diagnostic[{index}] must be an object")
+            bind_name = diagnostic.get("BindName")
+            message = diagnostic.get("Message")
+            level = diagnostic.get("Level")
+            if not isinstance(bind_name, str) or not bind_name:
+                raise RuleError(f"{path}: Diagnostic[{index}].BindName must be non-empty")
+            if not isinstance(message, str) or not message.strip():
+                raise RuleError(f"{path}: Diagnostic[{index}].Message must be non-empty")
+            if level not in {"Warning", "Note"}:
+                raise RuleError(f"{path}: Diagnostic[{index}].Level must be Warning or Note")
+            if level == "Warning":
+                warning_count += 1
+
+        if warning_count == 0:
+            raise RuleError(f"{path}: at least one diagnostic must have Level=Warning")
+
+        unknown = set(rule) - {"Name", "Query", "Diagnostic"}
+        if unknown:
+            raise RuleError(f"{path}: unsupported fields: {', '.join(sorted(unknown))}")
+
+        rules.append(rule)
+
+    return rules
+
+
+def build_config(rules: list[dict]) -> dict:
+    return {
+        "Checks": "-*,custom-qt-kde-lint-*",
+        "CustomChecks": rules,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--rules-dir", type=Path, default=Path("rules"))
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    try:
+        rules = load_rules(args.rules_dir.glob("*.json"))
+    except RuleError as exc:
+        parser.error(str(exc))
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(build_config(rules), indent=2) + "\n", encoding="utf-8")
+    print(f"generated {args.output} with {len(rules)} rule(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/test_rules.py
+++ b/tools/test_rules.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Run positive and negative regression fixtures for every declarative rule."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+
+from build_config import RuleError, build_config, load_rules
+
+
+def run_fixture(clang_tidy: str, config_path: Path, source: Path, include_dir: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            clang_tidy,
+            "--experimental-custom-checks",
+            f"--config-file={config_path}",
+            str(source),
+            "--",
+            "-std=c++20",
+            f"-I{include_dir}",
+        ],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+
+
+def fixtures(directory: Path, prefix: str) -> list[Path]:
+    return sorted(directory.glob(f"{prefix}*.cpp"))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--clang-tidy", default="clang-tidy-23")
+    parser.add_argument("--rules-dir", type=Path, default=Path("rules"))
+    parser.add_argument("--tests-dir", type=Path, default=Path("tests"))
+    args = parser.parse_args()
+
+    try:
+        rules = load_rules(args.rules_dir.glob("*.json"))
+    except RuleError as exc:
+        parser.error(str(exc))
+
+    if not rules:
+        print("no declarative rules yet; rule harness is ready")
+        return 0
+
+    failures: list[str] = []
+    include_dir = args.tests_dir / "include"
+
+    with tempfile.TemporaryDirectory(prefix="qt-kde-lint-") as temp_dir:
+        config_path = Path(temp_dir) / ".clang-tidy"
+        config_path.write_text(json.dumps(build_config(rules), indent=2) + "\n", encoding="utf-8")
+
+        for rule in rules:
+            name = rule["Name"]
+            marker = f"[custom-{name}]"
+            rule_tests = args.tests_dir / name
+            bad = fixtures(rule_tests, "bad")
+            good = fixtures(rule_tests, "good")
+
+            if not bad:
+                failures.append(f"{name}: missing tests/{name}/bad*.cpp fixture")
+            if not good:
+                failures.append(f"{name}: missing tests/{name}/good*.cpp fixture")
+            if not bad or not good:
+                continue
+
+            for source in bad:
+                result = run_fixture(args.clang_tidy, config_path, source, include_dir)
+                if marker not in result.stdout:
+                    failures.append(
+                        f"{name}: {source} did not emit {marker}\n--- clang-tidy output ---\n{result.stdout}"
+                    )
+
+            for source in good:
+                result = run_fixture(args.clang_tidy, config_path, source, include_dir)
+                if marker in result.stdout:
+                    failures.append(
+                        f"{name}: {source} unexpectedly emitted {marker}\n--- clang-tidy output ---\n{result.stdout}"
+                    )
+
+    if failures:
+        print("\n\n".join(failures))
+        return 1
+
+    print(f"all {len(rules)} declarative rule(s) passed regression tests")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Intent

Bootstrap `qt-kde-lint` as a rule suite layered on existing compiler diagnostics, clang-tidy, and Clazy rather than as a new C++ parser/linter.

The initial target is LLVM 23 query-based custom clang-tidy checks. The repository keeps individual rule definitions separate from generated clang-tidy configuration so the corpus can survive changes to the currently experimental LLVM schema.

## What this establishes

- documents the layered architecture and high-precision rule policy;
- requires stable `qt-kde-lint-*` rule names and explanatory diagnostics;
- requires each rule to arrive with triggering and non-triggering regression fixtures;
- stores one declarative rule per JSON file and generates the combined clang-tidy config;
- adds standard-library-only validation tooling and harness tests;
- adds CI pinned to clang-tidy 23 for declarative rule regression testing;
- documents that generally useful Qt rules should be considered for Clazy upstreaming rather than permanently duplicated here.

## Rule workflow

Actual lint rules are intentionally not included in this PR. New rules should normally be one rule per PR with evidence/motivation plus `bad*.cpp` and `good*.cpp` tests.

## References

- LLVM 23 query-based custom checks: https://releases.llvm.org/23.1.0/tools/clang/tools/extra/docs/clang-tidy/QueryBasedCustomChecks.html
- clang-tidy custom check guidance: https://releases.llvm.org/23.1.0/tools/clang/tools/extra/docs/clang-tidy/Contributing.html
- Clazy: https://github.com/KDE/clazy

## Deliberately deferred

A project license has not been selected here. Existing nearby repositories use different GPL versions, so this bootstrap does not infer a legal choice silently.
