### PR TITLE
rule: catch discarded QThread::create results

### DIFF
--- a/docs/rules/qt-kde-lint-qthread-create-immediate-start.md
+++ b/docs/rules/qt-kde-lint-qthread-create-immediate-start.md
@@ -1,0 +1,42 @@
+# `qt-kde-lint-qthread-create-immediate-start`
+
+Warn when code immediately calls `start()` on the pointer returned by `QThread::create()` and then discards that pointer.
+
+## Why
+
+`QThread::create()` creates and returns a `QThread` object. Starting that object without retaining the returned pointer leaves no owner or handle through which the caller can manage the `QThread` object's lifetime. Qt's QThread documentation recommends arranging deletion after completion, commonly by connecting `QThread::finished` to `QObject::deleteLater`.
+
+The diagnostic deliberately targets only the unambiguous chained form:
+
+```cpp
+QThread::create([] { doWork(); })->start();
+```
+
+It does not diagnose retaining the returned pointer and starting it later.
+
+## Evidence
+
+This pattern was found while reviewing generated asynchronous-thread code in `arran4/kjules` PR #305. Review feedback required keeping the `QThread *`, arranging `finished` -> `deleteLater`, and only then starting it:
+
+- https://github.com/arran4/kjules/pull/305
+- https://github.com/arran4/kjules/pull/305#discussion_r3323827134
+
+The final PR code uses the managed form in its thread benchmark.
+
+## Existing tooling
+
+The current Clazy check catalogue contains numerous thread-, QObject-, connect-, and lifetime-related checks, but no check specifically covering an immediately discarded `QThread::create()` result. No current built-in clang-tidy check was found that is Qt-specific enough to cover this expression.
+
+This local rule is intentionally narrower than a general QThread lifetime analysis. A broader lifetime rule should only be added if additional evidence can be matched without materially increasing false positives.
+
+## Repair direction
+
+Retain the returned pointer and define its ownership/lifetime before starting the thread. A common fire-and-clean-up pattern is:
+
+```cpp
+auto *thread = QThread::create([] { doWork(); });
+QObject::connect(thread, &QThread::finished, thread, &QObject::deleteLater);
+thread->start();
+```
+
+Project-specific ownership or cancellation requirements may call for a different lifetime strategy.

--- a/rules/qt-kde-lint-qthread-create-immediate-start.json
+++ b/rules/qt-kde-lint-qthread-create-immediate-start.json
@@ -1,0 +1,11 @@
+{
+  "Name": "qt-kde-lint-qthread-create-immediate-start",
+  "Query": "match cxxMemberCallExpr(\n  callee(cxxMethodDecl(hasName(\"::QThread::start\"))),\n  on(callExpr(hasDeclaration(functionDecl(hasName(\"::QThread::create\")))))\n).bind(\"start\")",
+  "Diagnostic": [
+    {
+      "BindName": "start",
+      "Message": "QThread::create() returns a heap-allocated QThread whose lifetime must be managed, but this code immediately starts it and discards the only returned pointer. Retain the QThread pointer and arrange a defined lifetime (commonly connect QThread::finished to QObject::deleteLater) before calling start(); otherwise the QThread object cannot be reclaimed or controlled after launch.",
+      "Level": "Warning"
+    }
+  ]
+}

--- a/tests/qt-kde-lint-qthread-create-immediate-start/bad.cpp
+++ b/tests/qt-kde-lint-qthread-create-immediate-start/bad.cpp
@@ -1,0 +1,11 @@
+class QThread {
+public:
+  template <typename Function> static QThread *create(Function &&function) {
+    (void)function;
+    return nullptr;
+  }
+
+  void start();
+};
+
+void launchWork() { QThread::create([] {})->start(); }

--- a/tests/qt-kde-lint-qthread-create-immediate-start/good.cpp
+++ b/tests/qt-kde-lint-qthread-create-immediate-start/good.cpp
@@ -1,0 +1,25 @@
+class QThread {
+public:
+  template <typename Function> static QThread *create(Function &&function) {
+    (void)function;
+    return nullptr;
+  }
+
+  void start();
+};
+
+QThread *makeThread();
+
+void retainedCreatedThread() {
+  QThread *thread = QThread::create([] {});
+  if (thread) {
+    thread->start();
+  }
+}
+
+void ordinaryThread() {
+  QThread thread;
+  thread.start();
+}
+
+void unrelatedFactory() { makeThread()->start(); }


### PR DESCRIPTION
## Intent

Add the first evidence-backed Qt lifetime rule: diagnose the unambiguous chained form where code calls `start()` directly on `QThread::create(...)` and immediately loses the returned `QThread *`.

```cpp
QThread::create([] { doWork(); })->start();
```

`QThread::create()` creates a `QThread` object. Discarding its pointer immediately after `start()` leaves the caller without an owner/handle for the QThread object's lifetime. Qt documents connecting `QThread::finished` to `QObject::deleteLater` as the common cleanup pattern for dynamically allocated threads.

## Evidence

This was found in generated async/thread code during review of `arran4/kjules#305`:

- https://github.com/arran4/kjules/pull/305
- review finding: https://github.com/arran4/kjules/pull/305#discussion_r3323827134

The review correction retained the thread pointer, arranged `finished` -> `deleteLater`, and then called `start()`.

This is currently one observed occurrence rather than a demonstrated recurrent family. It is still proposed because the matcher is intentionally narrow and the diagnosed form has no useful ownership semantics. Broader QThread-lifetime analysis is explicitly out of scope until more evidence exists.

## Existing-tool check

The current Clazy catalogue contains thread/connect/QObject checks but no check specifically for an immediately discarded `QThread::create()` result. I also did not find a built-in clang-tidy check that models this Qt-specific factory/lifetime pattern.

Clazy catalogue: https://github.com/KDE/clazy#list-of-checks
Qt QThread documentation: https://doc.qt.io/qt-6/qthread.html

## Diagnostic

The warning explains that the returned QThread is heap allocated, that the pointer has been discarded, and that the repair is to retain it and establish a lifetime (commonly `finished` -> `deleteLater`) before `start()`.

## Precision / non-trigger cases

The regression fixtures ensure the rule does **not** warn for:

- a retained `QThread::create()` result that is started later;
- an ordinary QThread object's `start()` call;
- a `QThread *` returned by an unrelated factory and immediately started.

## Tests

- `tests/qt-kde-lint-qthread-create-immediate-start/bad.cpp` must emit the stable rule ID.
- `tests/qt-kde-lint-qthread-create-immediate-start/good.cpp` must not emit it.
- CI executes the matcher through pinned `clang-tidy-23 --experimental-custom-checks`.
