### PR TITLE
docs: add GitHub Actions integration guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ Query-based custom checks currently require `--experimental-custom-checks`. The 
 
 `qt-kde-lint` is intended to run as an additional static-analysis pass in the same CI pipeline that already builds Qt/KDE code. It should **not** replace the project's normal compiler warnings, `.clang-tidy`, Clazy, `cppcheck`, formatting, build, or tests.
 
+The instructions below are intended to work with common Qt/KDE GitHub Actions layouts, including:
+
+- a dedicated C++/Qt lint job that already creates `compile_commands.json` and runs clang-tidy;
+- a combined build/test job where static analysis is currently limited to formatting or `cppcheck`;
+- container-based jobs using a KDE/openSUSE, Debian, Ubuntu, or similar build environment.
+
 A consumer workflow needs three things:
 
 1. a CMake compilation database generated with `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON`;
@@ -59,7 +65,7 @@ The generated configuration intentionally enables only `custom-qt-kde-lint-*`. R
 
 ### Minimal addition to an existing Qt/C++ lint job
 
-This is the shape to add after the project's existing CMake configure step:
+If a lint job already configures the project with `CMAKE_EXPORT_COMPILE_COMMANDS=ON`, add the following after configuration and after any existing clang-tidy/Clazy checks:
 
 ```yaml
       - name: Check out qt-kde-lint
@@ -101,44 +107,9 @@ The project's configure command must include the compilation database flag, for 
           -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 ```
 
-### Installing clang-tidy 23
+### Keep the existing lint pass separate
 
-Do not assume that an image's unversioned `clang-tidy` or `clang-tools` package is new enough. Verify the major version explicitly.
-
-This repository's own CI uses the LLVM apt repository on Ubuntu 24.04:
-
-```yaml
-      - name: Install LLVM 23 clang-tidy
-        run: |
-          wget -q https://apt.llvm.org/llvm.sh
-          chmod +x llvm.sh
-          sudo ./llvm.sh 23
-          sudo apt-get install -y clang-tidy-23
-          clang-tidy-23 --version
-```
-
-On a Debian image where `clang-tidy-23` is available directly, install the versioned package and still call the versioned executable:
-
-```yaml
-      - run: apt-get update && apt-get install -y python3 clang-tidy-23
-      - run: clang-tidy-23 --version
-```
-
-If the Qt/KDE build image does not provide clang-tidy 23 yet, keep the existing lint/build job unchanged and add a dedicated qt-kde-lint job using an LLVM-23-capable image with the same project development dependencies. Do not silently fall back to clang-tidy 22 or older: those versions do not provide the custom-check interface this repository currently targets.
-
-### Example matching `kjules` / `KMagMux`
-
-[`kjules`](https://github.com/arran4/kjules/blob/main/.github/workflows/ci.yaml) and [`KMagMux`](https://github.com/arran4/KMagMux/blob/main/.github/workflows/ci.yml) already have the important part of the integration: a dedicated Qt/C++ lint job that configures CMake with `CMAKE_EXPORT_COMPILE_COMMANDS=ON` and then runs clang-tidy against `build/`.
-
-For that workflow shape:
-
-1. leave the existing format, `cppcheck`, clang-tidy and Clazy-style checks in place;
-2. after CMake configuration, check out `arran4/qt-kde-lint` into `.qt-kde-lint`;
-3. make sure that lint environment has `python3` and `clang-tidy-23`;
-4. generate `build/qt-kde-lint.clang-tidy`;
-5. run the separate qt-kde-lint command from the minimal example above.
-
-For example, the relevant part should conceptually become:
+A workflow that already runs clang-tidy should normally look conceptually like this:
 
 ```yaml
       - name: Configure CMake
@@ -147,8 +118,8 @@ For example, the relevant part should conceptually become:
           -DQT_MAJOR_VERSION=6 \
           -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 
-      - name: Existing clang-tidy
-        run: run-clang-tidy -p build -extra-arg=-Wno-unknown-argument src tests bench
+      - name: Existing clang-tidy and Clazy checks
+        run: run-clang-tidy -p build src tests
 
       - name: Check out qt-kde-lint
         uses: actions/checkout@v4
@@ -162,7 +133,7 @@ For example, the relevant part should conceptually become:
           python3 .qt-kde-lint/tools/build_config.py \
             --rules-dir .qt-kde-lint/rules \
             --output build/qt-kde-lint.clang-tidy
-          find src tests bench -type f \
+          find src tests -type f \
             \( -name '*.cpp' -o -name '*.cc' -o -name '*.cxx' \) \
             -print0 2>/dev/null \
             | xargs -0 -r clang-tidy-23 \
@@ -171,19 +142,17 @@ For example, the relevant part should conceptually become:
                 -p build
 ```
 
-The existing `kjules` lint step currently soft-fails its normal clang-tidy invocation with `|| true`. That may be useful while migrating existing warnings, but the new qt-kde-lint step should not inherit that behavior: these rules are deliberately designed to be low-noise and merge-blocking.
+The important point is that the project's normal `.clang-tidy` remains authoritative for its existing checks, while qt-kde-lint supplies a separate generated configuration containing only this project's custom checks.
 
-### Example matching `kllamabooks` / `kgithub-notify`
+### Separate analysis job when the build job does not run clang-tidy
 
-[`kllamabooks`](https://github.com/arran4/kllamabooks/blob/main/.github/workflows/ci.yml) and [`kgithub-notify`](https://github.com/arran4/kgithub-notify/blob/main/.github/workflows/ci.yml) currently perform formatting/static analysis and build/test work in Debian-based jobs but do not generate a compilation database for a clang-tidy pass.
+If the existing build/test job does not export a compilation database, adding a sibling analysis job is often less disruptive than changing the build pipeline. The analysis job only needs enough Qt/KF development dependencies for CMake to configure successfully and clang-tidy to parse the actual translation units.
 
-The least disruptive integration is to add a sibling `qt-kde-lint` job and copy the project's normal Qt/KF development-package installation into it. For example:
+For example:
 
 ```yaml
   qt-kde-lint:
     name: qt-kde-lint
-    needs: [route, discover]
-    if: ${{ needs.discover.outputs.has_qt_cpp == 'true' && needs.route.outputs.run_code_checks == 'true' }}
     runs-on: ubuntu-latest
     container:
       # Use an image/repository combination that actually provides clang-tidy-23.
@@ -196,8 +165,8 @@ The least disruptive integration is to add a sibling `qt-kde-lint` job and copy 
             qt6-base-dev qt6-svg-dev qt6-tools-dev qt6-tools-dev-tools \
             libkf6coreaddons-dev libkf6xmlgui-dev libkf6configwidgets-dev \
             libkf6i18n-dev
-          # Add the same extra Qt/KF/project development packages used by the
-          # repository's normal build job.
+          # Add the same extra Qt/KF/project development packages needed by
+          # the repository's normal CMake configure step.
 
       - uses: actions/checkout@v4
 
@@ -228,18 +197,56 @@ The least disruptive integration is to add a sibling `qt-kde-lint` job and copy 
                 -p build
 ```
 
-Keep the existing build/test job on its preferred distribution if desired. The analysis job only needs to configure the project successfully and expose the same headers/compile definitions closely enough for clang-tidy to parse the real translation units.
+Keep the normal build/test job on its preferred distribution if desired. The analysis job only needs to configure the project successfully and expose the same headers, generated files, include paths, compile definitions, and language options closely enough for clang-tidy to parse the real build.
 
-### `kbrowserselect`
+### Installing clang-tidy 23
 
-[`kbrowserselect`](https://github.com/arran4/kbrowserselect/blob/main/.github/workflows/ci.yml) currently has its Qt/C++ build/test job disabled with `if: false`, and its lint/build commands are also guarded by `|| true`. Adding qt-kde-lint there only becomes meaningful after the Qt/C++ CI job is enabled. When doing so:
+Do not assume that an image's unversioned `clang-tidy` or `clang-tools` package is new enough. Verify the major version explicitly.
 
-- add `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON` to its CMake configure command;
-- use clang-tidy 23 or newer;
-- run qt-kde-lint as a separate pass;
-- do not use `|| true` for the qt-kde-lint command.
+This repository's own CI uses the LLVM apt repository on Ubuntu 24.04:
 
-That makes a qt-kde-lint finding an actual automated-test failure rather than informational log output.
+```yaml
+      - name: Install LLVM 23 clang-tidy
+        run: |
+          wget -q https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 23
+          sudo apt-get install -y clang-tidy-23
+          clang-tidy-23 --version
+```
+
+On an image where `clang-tidy-23` is available directly, install the versioned package and still call the versioned executable:
+
+```yaml
+      - run: apt-get update && apt-get install -y python3 clang-tidy-23
+      - run: clang-tidy-23 --version
+```
+
+If the normal Qt/KDE build image does not provide clang-tidy 23 yet, keep the existing lint/build job unchanged and add a dedicated qt-kde-lint job using an LLVM-23-capable image with the same project development dependencies. Do not silently fall back to clang-tidy 22 or older: those versions do not provide the custom-check interface this repository currently targets.
+
+### CI enforcement
+
+For automated testing, qt-kde-lint must run in a job that actually executes for pull requests and pushes where code checks are expected.
+
+Avoid these patterns for the qt-kde-lint step:
+
+```yaml
+if: false
+```
+
+and:
+
+```sh
+clang-tidy-23 ... || true
+```
+
+Either makes the integration informational rather than protective. The intended behavior is:
+
+1. CMake configuration fails if the project cannot be analyzed correctly;
+2. qt-kde-lint diagnostics make the step fail;
+3. that job is included in the repository's required GitHub status checks before merge.
+
+Existing legacy/static-analysis steps may temporarily soft-fail while their warning backlog is being migrated, but qt-kde-lint rules are intended to be low-noise enough to be merge-blocking from the point they are adopted.
 
 ### Why checkout the rules instead of copying them into each project?
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,208 @@ python3 tools/test_rules.py --clang-tidy clang-tidy-23
 
 Query-based custom checks currently require `--experimental-custom-checks`. The CI workflow pins the intended clang-tidy major rather than relying on the GitHub runner default.
 
+## GitHub Actions integration
+
+`qt-kde-lint` is intended to run as an additional static-analysis pass in the same CI pipeline that already builds Qt/KDE code. It should **not** replace the project's normal compiler warnings, `.clang-tidy`, Clazy, `cppcheck`, formatting, build, or tests.
+
+A consumer workflow needs three things:
+
+1. a CMake compilation database generated with `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON`;
+2. clang-tidy 23 or newer, because query-based custom checks are currently experimental;
+3. a checkout of this repository so `tools/build_config.py` can generate the custom-check configuration.
+
+The generated configuration intentionally enables only `custom-qt-kde-lint-*`. Run it as a **second clang-tidy pass** rather than supplying it to the project's normal clang-tidy invocation, otherwise the generated `Checks: -*,custom-qt-kde-lint-*` setting would replace the project's normal check selection.
+
+### Minimal addition to an existing Qt/C++ lint job
+
+This is the shape to add after the project's existing CMake configure step:
+
+```yaml
+      - name: Check out qt-kde-lint
+        uses: actions/checkout@v4
+        with:
+          repository: arran4/qt-kde-lint
+          # Pin a release tag or commit for reproducible CI once releases exist.
+          ref: main
+          path: .qt-kde-lint
+
+      - name: Generate qt-kde-lint configuration
+        run: |
+          python3 .qt-kde-lint/tools/build_config.py \
+            --rules-dir .qt-kde-lint/rules \
+            --output build/qt-kde-lint.clang-tidy
+
+      - name: Run qt-kde-lint
+        run: |
+          clang-tidy-23 --version
+          find src tests bench -type f \
+            \( -name '*.cpp' -o -name '*.cc' -o -name '*.cxx' \) \
+            -print0 2>/dev/null \
+            | xargs -0 -r clang-tidy-23 \
+                --experimental-custom-checks \
+                --config-file=build/qt-kde-lint.clang-tidy \
+                -p build
+```
+
+Adjust the source directories for the project. Running translation units from the compilation database is sufficient to analyze code in included headers as well; there is normally no need to invoke clang-tidy separately on every header.
+
+Do **not** append `|| true` to the qt-kde-lint step. A diagnostic is supposed to fail automated testing so the mistake is repaired before merge.
+
+The project's configure command must include the compilation database flag, for example:
+
+```yaml
+      - name: Configure CMake
+        run: cmake -B build -S . -G Ninja \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+```
+
+### Installing clang-tidy 23
+
+Do not assume that an image's unversioned `clang-tidy` or `clang-tools` package is new enough. Verify the major version explicitly.
+
+This repository's own CI uses the LLVM apt repository on Ubuntu 24.04:
+
+```yaml
+      - name: Install LLVM 23 clang-tidy
+        run: |
+          wget -q https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 23
+          sudo apt-get install -y clang-tidy-23
+          clang-tidy-23 --version
+```
+
+On a Debian image where `clang-tidy-23` is available directly, install the versioned package and still call the versioned executable:
+
+```yaml
+      - run: apt-get update && apt-get install -y python3 clang-tidy-23
+      - run: clang-tidy-23 --version
+```
+
+If the Qt/KDE build image does not provide clang-tidy 23 yet, keep the existing lint/build job unchanged and add a dedicated qt-kde-lint job using an LLVM-23-capable image with the same project development dependencies. Do not silently fall back to clang-tidy 22 or older: those versions do not provide the custom-check interface this repository currently targets.
+
+### Example matching `kjules` / `KMagMux`
+
+[`kjules`](https://github.com/arran4/kjules/blob/main/.github/workflows/ci.yaml) and [`KMagMux`](https://github.com/arran4/KMagMux/blob/main/.github/workflows/ci.yml) already have the important part of the integration: a dedicated Qt/C++ lint job that configures CMake with `CMAKE_EXPORT_COMPILE_COMMANDS=ON` and then runs clang-tidy against `build/`.
+
+For that workflow shape:
+
+1. leave the existing format, `cppcheck`, clang-tidy and Clazy-style checks in place;
+2. after CMake configuration, check out `arran4/qt-kde-lint` into `.qt-kde-lint`;
+3. make sure that lint environment has `python3` and `clang-tidy-23`;
+4. generate `build/qt-kde-lint.clang-tidy`;
+5. run the separate qt-kde-lint command from the minimal example above.
+
+For example, the relevant part should conceptually become:
+
+```yaml
+      - name: Configure CMake
+        run: cmake -B build -S . -G Ninja \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DQT_MAJOR_VERSION=6 \
+          -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+
+      - name: Existing clang-tidy
+        run: run-clang-tidy -p build -extra-arg=-Wno-unknown-argument src tests bench
+
+      - name: Check out qt-kde-lint
+        uses: actions/checkout@v4
+        with:
+          repository: arran4/qt-kde-lint
+          ref: main
+          path: .qt-kde-lint
+
+      - name: qt-kde-lint
+        run: |
+          python3 .qt-kde-lint/tools/build_config.py \
+            --rules-dir .qt-kde-lint/rules \
+            --output build/qt-kde-lint.clang-tidy
+          find src tests bench -type f \
+            \( -name '*.cpp' -o -name '*.cc' -o -name '*.cxx' \) \
+            -print0 2>/dev/null \
+            | xargs -0 -r clang-tidy-23 \
+                --experimental-custom-checks \
+                --config-file=build/qt-kde-lint.clang-tidy \
+                -p build
+```
+
+The existing `kjules` lint step currently soft-fails its normal clang-tidy invocation with `|| true`. That may be useful while migrating existing warnings, but the new qt-kde-lint step should not inherit that behavior: these rules are deliberately designed to be low-noise and merge-blocking.
+
+### Example matching `kllamabooks` / `kgithub-notify`
+
+[`kllamabooks`](https://github.com/arran4/kllamabooks/blob/main/.github/workflows/ci.yml) and [`kgithub-notify`](https://github.com/arran4/kgithub-notify/blob/main/.github/workflows/ci.yml) currently perform formatting/static analysis and build/test work in Debian-based jobs but do not generate a compilation database for a clang-tidy pass.
+
+The least disruptive integration is to add a sibling `qt-kde-lint` job and copy the project's normal Qt/KF development-package installation into it. For example:
+
+```yaml
+  qt-kde-lint:
+    name: qt-kde-lint
+    needs: [route, discover]
+    if: ${{ needs.discover.outputs.has_qt_cpp == 'true' && needs.route.outputs.run_code_checks == 'true' }}
+    runs-on: ubuntu-latest
+    container:
+      # Use an image/repository combination that actually provides clang-tidy-23.
+      image: debian:sid
+    steps:
+      - run: |
+          apt-get update
+          apt-get install -y \
+            git python3 cmake ninja-build build-essential clang-tidy-23 \
+            qt6-base-dev qt6-svg-dev qt6-tools-dev qt6-tools-dev-tools \
+            libkf6coreaddons-dev libkf6xmlgui-dev libkf6configwidgets-dev \
+            libkf6i18n-dev
+          # Add the same extra Qt/KF/project development packages used by the
+          # repository's normal build job.
+
+      - uses: actions/checkout@v4
+
+      - name: Check out qt-kde-lint
+        uses: actions/checkout@v4
+        with:
+          repository: arran4/qt-kde-lint
+          ref: main
+          path: .qt-kde-lint
+
+      - name: Configure CMake for analysis
+        run: cmake -S . -B build -G Ninja \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+
+      - name: Run qt-kde-lint
+        run: |
+          clang-tidy-23 --version
+          python3 .qt-kde-lint/tools/build_config.py \
+            --rules-dir .qt-kde-lint/rules \
+            --output build/qt-kde-lint.clang-tidy
+          find src tests -type f \
+            \( -name '*.cpp' -o -name '*.cc' -o -name '*.cxx' \) \
+            -print0 2>/dev/null \
+            | xargs -0 -r clang-tidy-23 \
+                --experimental-custom-checks \
+                --config-file=build/qt-kde-lint.clang-tidy \
+                -p build
+```
+
+Keep the existing build/test job on its preferred distribution if desired. The analysis job only needs to configure the project successfully and expose the same headers/compile definitions closely enough for clang-tidy to parse the real translation units.
+
+### `kbrowserselect`
+
+[`kbrowserselect`](https://github.com/arran4/kbrowserselect/blob/main/.github/workflows/ci.yml) currently has its Qt/C++ build/test job disabled with `if: false`, and its lint/build commands are also guarded by `|| true`. Adding qt-kde-lint there only becomes meaningful after the Qt/C++ CI job is enabled. When doing so:
+
+- add `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON` to its CMake configure command;
+- use clang-tidy 23 or newer;
+- run qt-kde-lint as a separate pass;
+- do not use `|| true` for the qt-kde-lint command.
+
+That makes a qt-kde-lint finding an actual automated-test failure rather than informational log output.
+
+### Why checkout the rules instead of copying them into each project?
+
+Keeping the rule definitions in this repository means every consumer runs the same rule IDs, diagnostics, regression-tested matchers, and fixes. Once stable releases/tags exist, consumers should pin the checkout to a tag or commit and update it deliberately, rather than duplicating rule JSON into each Qt/KDE repository.
+
+A reusable/composite GitHub Action may be added later to hide the checkout/config-generation boilerplate. Until that exists, the explicit steps above make the compiler version, compilation database, and rule source visible in each consuming workflow.
+
 ## Status
 
 The repository is being built incrementally. Infrastructure changes may share a PR, but actual lint rules should normally remain one rule per PR so their evidence, tests, false-positive tradeoffs, and history stay independently reviewable.


### PR DESCRIPTION
Documents how to consume qt-kde-lint from GitHub Actions without replacing existing clang-tidy/Clazy checks.

The guidance is intentionally generic and is designed to work across common Qt/KDE CI shapes, including:

- dedicated Qt/C++ lint jobs that already generate `compile_commands.json`;
- combined build/test jobs that need a sibling analysis job;
- container-based workflows using KDE/openSUSE, Debian, Ubuntu, or similar environments.

Key points documented:

- generate a CMake compilation database with `CMAKE_EXPORT_COMPILE_COMMANDS=ON`;
- run qt-kde-lint as a separate clang-tidy pass because its generated config enables only `custom-qt-kde-lint-*`;
- pin/use clang-tidy 23+ and pass `--experimental-custom-checks`;
- check out this repository and generate the config at CI time instead of copying rule JSON into consumers;
- do not soft-fail the qt-kde-lint step with `|| true`;
- keep existing compiler, clang-tidy, Clazy, cppcheck, formatting, build, and test checks intact;
- ensure the qt-kde-lint job actually runs for PRs/pushes and is suitable as a required status check;
- recommend pinning a release tag/commit once stable releases exist.

This is documentation-only and does not change the rule harness or CI behavior.