### PR TITLE
Add custom lint rule for KXmlGuiWindow manual menus

### DIFF
--- a/rules/qt-kde-lint-kxmlguiwindow-manual-menus.json
+++ b/rules/qt-kde-lint-kxmlguiwindow-manual-menus.json
@@ -1,0 +1,11 @@
+{
+  "Name": "qt-kde-lint-kxmlguiwindow-manual-menus",
+  "Query": "match cxxMemberCallExpr(callee(cxxMethodDecl(anyOf(allOf(hasName(\"addMenu\"), ofClass(hasName(\"::QMenuBar\"))), allOf(hasName(\"addToolBar\"), ofClass(hasName(\"::QMainWindow\")))))), hasAncestor(cxxMethodDecl(hasDescendant(cxxMemberCallExpr(callee(cxxMethodDecl(hasName(\"setupGUI\"))))), ofClass(cxxRecordDecl(isDerivedFrom(anyOf(hasName(\"::KXmlGuiWindow\"), hasName(\"::KMainWindow\")))))))).bind(\"problem\")",
+  "Diagnostic": [
+    {
+      "BindName": "problem",
+      "Message": "This KXmlGuiWindow manually builds top-level menus/toolbars while also using setupGUI(). Register persistent actions in actionCollection() and place them through the XMLGUI resource; XMLGUI may replace containers and manual additions can disappear, duplicate, or leave stale widget pointers.",
+      "Level": "Warning"
+    }
+  ]
+}

--- a/tests/include/kmainwindow.h
+++ b/tests/include/kmainwindow.h
@@ -1,0 +1,6 @@
+#pragma once
+#include "qmainwindow.h"
+class KMainWindow : public QMainWindow {
+public:
+    void setupGUI();
+};

--- a/tests/include/kxmlguiwindow.h
+++ b/tests/include/kxmlguiwindow.h
@@ -1,0 +1,6 @@
+#pragma once
+#include "qmainwindow.h"
+class KXmlGuiWindow : public QMainWindow {
+public:
+    void setupGUI();
+};

--- a/tests/include/qmainwindow.h
+++ b/tests/include/qmainwindow.h
@@ -1,0 +1,15 @@
+#pragma once
+#include "qstring.h"
+class QMenu;
+class QToolBar;
+class QMenuBar;
+class QMainWindow {
+public:
+    QMenuBar* menuBar() const;
+    QToolBar* addToolBar(const QString& title);
+};
+
+class QMenuBar {
+public:
+    QMenu* addMenu(const QString& title);
+};

--- a/tests/include/qstring.h
+++ b/tests/include/qstring.h
@@ -1,0 +1,5 @@
+#pragma once
+class QString {
+public:
+    QString(const char*);
+};

--- a/tests/qt-kde-lint-kxmlguiwindow-manual-menus/bad-2.cpp
+++ b/tests/qt-kde-lint-kxmlguiwindow-manual-menus/bad-2.cpp
@@ -1,0 +1,10 @@
+#include "kmainwindow.h"
+
+class MyMainWindow : public KMainWindow {
+public:
+    MyMainWindow() {
+        menuBar()->addMenu("File");
+        addToolBar("Main");
+        setupGUI();
+    }
+};

--- a/tests/qt-kde-lint-kxmlguiwindow-manual-menus/bad-3.cpp
+++ b/tests/qt-kde-lint-kxmlguiwindow-manual-menus/bad-3.cpp
@@ -1,0 +1,12 @@
+#include "kxmlguiwindow.h"
+
+class MyWindow : public KXmlGuiWindow {
+public:
+    MyWindow();
+};
+
+MyWindow::MyWindow() {
+    menuBar()->addMenu("File");
+    addToolBar("Main");
+    setupGUI();
+}

--- a/tests/qt-kde-lint-kxmlguiwindow-manual-menus/bad.cpp
+++ b/tests/qt-kde-lint-kxmlguiwindow-manual-menus/bad.cpp
@@ -1,0 +1,10 @@
+#include "kxmlguiwindow.h"
+
+class MyWindow : public KXmlGuiWindow {
+public:
+    MyWindow() {
+        menuBar()->addMenu("File");
+        addToolBar("Main");
+        setupGUI();
+    }
+};

--- a/tests/qt-kde-lint-kxmlguiwindow-manual-menus/good-2.cpp
+++ b/tests/qt-kde-lint-kxmlguiwindow-manual-menus/good-2.cpp
@@ -1,0 +1,25 @@
+#include "kxmlguiwindow.h"
+#include "kmainwindow.h"
+
+class QMenu {
+public:
+    QMenu* addMenu(const QString& title);
+};
+
+class MyWindow : public KXmlGuiWindow {
+public:
+    MyWindow() {
+        QMenu menu;
+        menu.addMenu("Submenu");
+        setupGUI();
+    }
+};
+
+class MyMainWindow : public KMainWindow {
+public:
+    MyMainWindow() {
+        QMenu menu;
+        menu.addMenu("Submenu");
+        setupGUI();
+    }
+};

--- a/tests/qt-kde-lint-kxmlguiwindow-manual-menus/good.cpp
+++ b/tests/qt-kde-lint-kxmlguiwindow-manual-menus/good.cpp
@@ -1,0 +1,16 @@
+#include "kxmlguiwindow.h"
+
+class MyWindow : public KXmlGuiWindow {
+public:
+    MyWindow() {
+        setupGUI();
+    }
+};
+
+class MyOtherWindow : public QMainWindow {
+public:
+    MyOtherWindow() {
+        menuBar()->addMenu("File");
+        addToolBar("Main");
+    }
+};


### PR DESCRIPTION
Adds `qt-kde-lint-kxmlguiwindow-manual-menus`, a declarative LLVM clang-tidy
custom check that warns when manual Qt menu construction (e.g. `QMenuBar::addMenu`
or `QMainWindow::addToolBar`) is mixed with `setupGUI()` in `KXmlGuiWindow` or
`KMainWindow` subclasses.

This practice can cause KDE XMLGUI to duplicate, overwrite, or hide UI elements
incorrectly. Includes comprehensive regression tests for inline and out-of-line
method definitions.

Fixes #10

---
*PR created automatically by Jules for task [14351071668712045370](https://jules.google.com/task/14351071668712045370) started by @arran4*