### PR TITLE
Add KActionCollection setShortcut rule

### DIFF
--- a/docs/rules/qt-kde-lint-kactioncollection-setshortcut.md
+++ b/docs/rules/qt-kde-lint-kactioncollection-setshortcut.md
@@ -1,0 +1,22 @@
+# qt-kde-lint-kactioncollection-setshortcut
+
+## Motivation
+Detect a `QAction` owned/registered by a KDE `KActionCollection` whose default shortcut is assigned with `QAction::setShortcut()` / `setShortcuts()` instead of `KActionCollection::setDefaultShortcut()` / `setDefaultShortcuts()`.
+
+Actions controlled by `KActionCollection` must expose framework-managed defaults so KDE shortcut configuration continues to work. Using `setShortcut()` on them causes `kf.xmlgui` shortcut warnings at runtime.
+
+### Examples
+Bad:
+```cpp
+QAction *zoomIn = actionCollection()->addAction(QStringLiteral("zoom_in"));
+zoomIn->setShortcut(QKeySequence::ZoomIn);
+```
+
+Preferred KDE form:
+```cpp
+QAction *zoomIn = actionCollection()->addAction(QStringLiteral("zoom_in"));
+actionCollection()->setDefaultShortcut(zoomIn, QKeySequence::ZoomIn);
+```
+
+### Reference
+See https://github.com/arran4/qt-kde-lint/issues/12

--- a/rules/qt-kde-lint-kactioncollection-setshortcut.json
+++ b/rules/qt-kde-lint-kactioncollection-setshortcut.json
@@ -1,0 +1,11 @@
+{
+  "Name": "qt-kde-lint-kactioncollection-setshortcut",
+  "Query": "match cxxMemberCallExpr(  callee(cxxMethodDecl(anyOf(hasName(\"setShortcut\"), hasName(\"setShortcuts\")), ofClass(hasName(\"QAction\")))),  anyOf(    on(declRefExpr(to(varDecl(hasInitializer(      expr(anyOf(        ignoringParenImpCasts(cxxMemberCallExpr(callee(cxxMethodDecl(hasName(\"addAction\"), ofClass(hasName(\"KActionCollection\")))))),        ignoringParenImpCasts(cStyleCastExpr(hasSourceExpression(ignoringParenImpCasts(callExpr(callee(functionDecl(hasDeclContext(namespaceDecl(hasName(\"KStandardAction\")))))))))),        ignoringParenImpCasts(callExpr(callee(functionDecl(hasDeclContext(namespaceDecl(hasName(\"KStandardAction\")))))))      ))    ))))),    on(ignoringParenImpCasts(cxxMemberCallExpr(callee(cxxMethodDecl(hasName(\"addAction\"), ofClass(hasName(\"KActionCollection\"))))))),    allOf(      on(declRefExpr(to(varDecl(hasType(pointsTo(cxxRecordDecl(hasName(\"QAction\"))))).bind(\"qaction_var\")))),      hasAncestor(compoundStmt(hasDescendant(        cxxMemberCallExpr(          callee(cxxMethodDecl(hasName(\"addAction\"), ofClass(hasName(\"KActionCollection\")))),          hasArgument(1, ignoringParenImpCasts(declRefExpr(to(varDecl(equalsBoundNode(\"qaction_var\"))))))        )      )))    )  )).bind(\"call\")",
+  "Diagnostic": [
+    {
+      "BindName": "call",
+      "Message": "This QAction is managed by KActionCollection, but its shortcut is assigned directly with QAction::setShortcut(). Set the collection's default shortcut with KActionCollection::setDefaultShortcut(s) so KDE can manage user overrides and avoid XMLGUI shortcut warnings.",
+      "Level": "Warning"
+    }
+  ]
+}

--- a/tests/qt-kde-lint-kactioncollection-setshortcut/bad.cpp
+++ b/tests/qt-kde-lint-kactioncollection-setshortcut/bad.cpp
@@ -1,0 +1,35 @@
+namespace KStandardAction {
+    class Action {};
+    Action* open(void*, void*, void*);
+}
+
+class QAction {
+public:
+    void setShortcut(int shortcut);
+    void setShortcuts(int shortcuts);
+};
+
+class KActionCollection {
+public:
+    QAction* addAction(const char* name);
+    QAction* addAction(const char* name, QAction* action);
+};
+
+KActionCollection* actionCollection();
+
+void test() {
+    QAction* zoomIn = actionCollection()->addAction("zoom_in");
+    zoomIn->setShortcut(1); // bad
+
+    QAction* zoomOut = actionCollection()->addAction("zoom_out");
+    zoomOut->setShortcuts(2); // bad
+
+    QAction* act1 = new QAction();
+    actionCollection()->addAction("act1", act1);
+    act1->setShortcut(1); // bad, passed to addAction
+
+    QAction* act2 = (QAction*)KStandardAction::open(nullptr, nullptr, actionCollection());
+    act2->setShortcut(2); // bad, returned from KStandardAction with collection
+
+    actionCollection()->addAction("act3", act1)->setShortcut(2); // bad, returned from addAction
+}

--- a/tests/qt-kde-lint-kactioncollection-setshortcut/good.cpp
+++ b/tests/qt-kde-lint-kactioncollection-setshortcut/good.cpp
@@ -1,0 +1,23 @@
+class QAction {
+public:
+    void setShortcut(int shortcut);
+    void setShortcuts(int shortcuts);
+};
+
+class KActionCollection {
+public:
+    QAction* addAction(const char* name);
+    QAction* addAction(const char* name, QAction* action);
+    void setDefaultShortcut(QAction* action, int shortcut);
+    void setDefaultShortcuts(QAction* action, int shortcuts);
+};
+
+KActionCollection* actionCollection();
+
+void test() {
+    QAction* zoomIn = actionCollection()->addAction("zoom_in");
+    actionCollection()->setDefaultShortcut(zoomIn, 1); // good
+
+    QAction* normal = new QAction();
+    normal->setShortcut(2); // good, not managed by KActionCollection
+}


### PR DESCRIPTION
Fixes issue #12 by introducing a rule that checks for direct usage of `setShortcut`/`setShortcuts` on a `QAction` that is managed by `KActionCollection`. This is meant to prevent runtime warnings generated by KDE's shortcut override system.

---
*PR created automatically by Jules for task [2373176591956490550](https://jules.google.com/task/2373176591956490550) started by @arran4*