### PR TITLE
Add rule: investigate missing semantic i18n context on KDE action labels

### DIFF
--- a/rules/qt-kde-lint-action-semantic-context.json
+++ b/rules/qt-kde-lint-action-semantic-context.json
@@ -1,0 +1,11 @@
+{
+  "Name": "qt-kde-lint-action-semantic-context",
+  "Query": "match callExpr(callee(functionDecl(anyOf(hasName(\"::i18n\"), hasName(\"::i18nd\"), hasName(\"::ki18n\"), hasName(\"::ki18nd\")))), anyOf(hasAncestor(cxxConstructExpr(hasDeclaration(cxxConstructorDecl(ofClass(hasName(\"::QAction\")))))), hasAncestor(cxxMemberCallExpr(callee(cxxMethodDecl(hasName(\"setText\"), ofClass(hasName(\"::QAction\")))))), hasAncestor(cxxMemberCallExpr(callee(cxxMethodDecl(hasName(\"addAction\"), ofClass(anyOf(hasName(\"::QMenu\"), hasName(\"::KActionCollection\"))))))))).bind(\"problem\")",
+  "Diagnostic": [
+    {
+      "BindName": "problem",
+      "Message": "UI action labels translated with plain i18n() lack semantic context. Where the surrounding API makes the action role unambiguous (like QAction::setText or QMenu::addAction), prefer i18nc() with a semantic context such as \"@action\", \"@action:inmenu\", or \"@action:button\" to aid translators.",
+      "Level": "Warning"
+    }
+  ]
+}

--- a/tests/qt-kde-lint-action-semantic-context/bad.cpp
+++ b/tests/qt-kde-lint-action-semantic-context/bad.cpp
@@ -1,0 +1,44 @@
+class QString {
+public:
+    QString(const char*);
+};
+
+class QObject {};
+
+class QAction {
+public:
+    QAction(const QString &text, QObject *parent = nullptr);
+    void setText(const QString &text);
+};
+
+class QMenu {
+public:
+    QAction *addAction(const QString &text);
+};
+
+class KActionCollection {
+public:
+    QAction *addAction(const QString &name, const QString &text, const QObject *receiver, const char *member);
+};
+
+QString i18n(const char*);
+QString i18nd(const char*, const char*);
+QString ki18n(const char*);
+QString ki18nd(const char*, const char*);
+
+void test() {
+    QAction *a = new QAction(i18n("Copy")); // bad
+    a->setText(i18n("Paste")); // bad
+
+    QMenu *m = new QMenu();
+    m->addAction(i18n("Cut")); // bad
+
+    KActionCollection *coll = new KActionCollection();
+    coll->addAction("name", i18n("Undo"), nullptr, nullptr); // bad
+
+    QAction *b = new QAction(ki18n("Copy")); // bad
+    b->setText(i18nd("domain", "Paste")); // bad
+
+    QMenu *m2 = new QMenu();
+    m2->addAction(ki18nd("domain", "Cut")); // bad
+}

--- a/tests/qt-kde-lint-action-semantic-context/good.cpp
+++ b/tests/qt-kde-lint-action-semantic-context/good.cpp
@@ -1,0 +1,48 @@
+class QString {
+public:
+    QString(const char*);
+};
+
+class QObject {};
+
+class QAction {
+public:
+    QAction(const QString &text, QObject *parent = nullptr);
+    void setText(const QString &text);
+};
+
+class QMenu {
+public:
+    QAction *addAction(const QString &text);
+};
+
+class KActionCollection {
+public:
+    QAction *addAction(const QString &name, const QString &text, const QObject *receiver, const char *member);
+};
+
+QString i18n(const char*);
+QString i18nc(const char*, const char*);
+QString i18ndc(const char*, const char*, const char*);
+QString ki18nc(const char*, const char*);
+QString ki18ndc(const char*, const char*, const char*);
+
+void test() {
+    QAction *a = new QAction(i18nc("@action", "Copy")); // good
+    a->setText(i18nc("@action", "Paste")); // good
+
+    QMenu *m = new QMenu();
+    m->addAction(i18nc("@action:inmenu", "Cut")); // good
+
+    KActionCollection *coll = new KActionCollection();
+    coll->addAction("name", i18nc("@action", "Undo"), nullptr, nullptr); // good
+
+    QAction *b = new QAction(ki18nc("@action", "Copy")); // good
+    b->setText(i18ndc("domain", "@action", "Paste")); // good
+
+    QMenu *m2 = new QMenu();
+    m2->addAction(ki18ndc("domain", "@action:inmenu", "Cut")); // good
+
+    // Unrelated use of i18n should not trigger
+    QString s = i18n("Normal text");
+}


### PR DESCRIPTION
Fixes #8. Added rule to detect missing semantic i18n context on KDE action labels.

---
*PR created automatically by Jules for task [14937018538529962466](https://jules.google.com/task/14937018538529962466) started by @arran4*