### PR TITLE
docs: record issue #5 as not planned

### DIFF
--- a/docs/rules/qml-transient-objects-no-destruction-strategy.md
+++ b/docs/rules/qml-transient-objects-no-destruction-strategy.md
@@ -1,0 +1,13 @@
+# Candidate rule: flag transient QML objects created repeatedly without a destruction strategy
+
+- **Status**: Not planned
+
+## Rationale
+
+This candidate rule aimed to flag dynamically created QML objects (e.g., from repeated interaction handlers) that are neither explicitly destroyed nor retained for deliberate reuse, leading to accumulation until the parent object is destroyed.
+
+However, implementing this rule effectively requires QML AST and lifetime reasoning to differentiate between objects intentionally kept alive for the lifetime of their parent and those that are leaked from transient interactions. A simple rule without such reasoning would be overly broad and result in a high rate of false positives.
+
+The current analysis stack for this project relies on Clang tooling (`clang-query` and `clang-tidy`), which provides robust C++ AST parsing and matching capabilities but does not support parsing or reasoning about QML. Adding dedicated QML parsing infrastructure is outside the scope of the initial ruleset.
+
+Because a low-false-positive formulation cannot be demonstrated using the existing toolchain, the implementation of this rule is not planned.

--- a/issues.md
+++ b/issues.md
@@ -1,8 +1,0 @@
-# Issues
-
-This file documents issues that have been considered but not implemented, along with the reasoning.
-
-## Issue #5: candidate rule: flag transient QML objects created repeatedly without a destruction strategy
-
-- **Status**: Not planned
-- **Reasoning**: This rule requires QML AST/lifetime reasoning to avoid high false-positive rates when differentiating between objects intentionally kept alive and those that are leaked from transient interactions. The current analysis stack relies on Clang tooling (`clang-query`/`clang-tidy`), which provides C++ AST parsing but does not support QML. Implementing a low-false-positive formulation is currently not feasible without adding dedicated QML parsing infrastructure. Therefore, this issue is closed as not planned for the initial ruleset.

--- a/issues.md
+++ b/issues.md
@@ -1,0 +1,8 @@
+# Issues
+
+This file documents issues that have been considered but not implemented, along with the reasoning.
+
+## Issue #5: candidate rule: flag transient QML objects created repeatedly without a destruction strategy
+
+- **Status**: Not planned
+- **Reasoning**: This rule requires QML AST/lifetime reasoning to avoid high false-positive rates when differentiating between objects intentionally kept alive and those that are leaked from transient interactions. The current analysis stack relies on Clang tooling (`clang-query`/`clang-tidy`), which provides C++ AST parsing but does not support QML. Implementing a low-false-positive formulation is currently not feasible without adding dedicated QML parsing infrastructure. Therefore, this issue is closed as not planned for the initial ruleset.


### PR DESCRIPTION
Documents issue #5 (candidate rule for transient QML objects) as Not planned, due to lack of QML AST parsing infrastructure in the current Clang-based setup.

Closes #5

---
*PR created automatically by Jules for task [7262073383200907099](https://jules.google.com/task/7262073383200907099) started by @arran4*