### PR TITLE
feat: Add rule for ambiguous QEventLoop timeouts

### DIFF
--- a/docs/rules/qt-kde-lint-ambiguous-qeventloop-timeout.md
+++ b/docs/rules/qt-kde-lint-ambiguous-qeventloop-timeout.md
@@ -1,0 +1,22 @@
+# qt-kde-lint-ambiguous-qeventloop-timeout
+
+## Rationale
+Code using a local `QEventLoop` that sets up an asynchronous operation's completion signal AND a `QTimer::singleShot` timeout, both to trigger `quit()`, creates an ambiguous loop exit.
+If the loop is quit, it could be because the operation completed, or because the timeout expired.
+Using the result of the asynchronous operation immediately after `exec()` without checking whether the completion signal actually occurred is unsafe, since the timeout path could have been hit and the operation may not have a valid result.
+
+## Evidence
+Found twice in KDE KWeather MR !162 / its merged KRunner implementation:
+* https://invent.kde.org/utilities/kweather/-/merge_requests/162
+* merged commit: KDE/kweather@ac960a5
+* source: https://github.com/KDE/kweather/blob/ac960a53d7ebb6ac0f71b2269f0b235def01e92f/src/krunner/kweatherrunner.cpp
+
+## Check
+The check looks for the pattern where:
+1. A local `QEventLoop` is declared.
+2. `QTimer::singleShot(..., &loop, &QEventLoop::quit)` is called.
+3. `connect(sender, ..., &loop, &QEventLoop::quit)` is called.
+4. `loop.exec()` is called.
+5. The `sender` object is used outside the `connect` call within the same compound block (this usually indicates reading `result()` or `error()`).
+
+If you handle this correctly (e.g., using a boolean `finished` flag set via a lambda), the direct connection to `&QEventLoop::quit` isn't made, or the `sender` isn't blindly used.

--- a/rules/qt-kde-lint-ambiguous-qeventloop-timeout.json
+++ b/rules/qt-kde-lint-ambiguous-qeventloop-timeout.json
@@ -1,0 +1,11 @@
+{
+  "Name": "qt-kde-lint-ambiguous-qeventloop-timeout",
+  "Query": "match compoundStmt(hasDescendant(cxxMemberCallExpr(callee(cxxMethodDecl(hasName(\"exec\"))), on(declRefExpr(to(varDecl(hasType(cxxRecordDecl(hasName(\"QEventLoop\")))).bind(\"loop\"))))).bind(\"exec\")), hasDescendant(callExpr(callee(functionDecl(hasName(\"singleShot\"))), hasArgument(1, unaryOperator(hasOperatorName(\"&\"), hasUnaryOperand(declRefExpr(to(varDecl(equalsBoundNode(\"loop\"))))))), hasArgument(2, unaryOperator(hasOperatorName(\"&\"), hasUnaryOperand(declRefExpr(to(cxxMethodDecl(hasName(\"quit\"))))))))), hasDescendant(callExpr(callee(functionDecl(hasName(\"connect\"))), hasArgument(2, unaryOperator(hasOperatorName(\"&\"), hasUnaryOperand(declRefExpr(to(varDecl(equalsBoundNode(\"loop\"))))))), hasArgument(3, unaryOperator(hasOperatorName(\"&\"), hasUnaryOperand(declRefExpr(to(cxxMethodDecl(hasName(\"quit\"))))))), hasArgument(0, expr(ignoringParenImpCasts(declRefExpr(to(decl().bind(\"sender\"))))))).bind(\"connect\")), hasDescendant(cxxMemberCallExpr(on(expr(ignoringParenImpCasts(declRefExpr(to(decl(equalsBoundNode(\"sender\"))))))))))",
+  "Diagnostic": [
+    {
+      "BindName": "exec",
+      "Message": "This local event loop can exit because either the operation finished or the timeout fired, but the result is used without distinguishing those paths. Track completion or handle the timeout explicitly before consuming the asynchronous result.",
+      "Level": "Warning"
+    }
+  ]
+}

--- a/tests/qt-kde-lint-ambiguous-qeventloop-timeout/bad.cpp
+++ b/tests/qt-kde-lint-ambiguous-qeventloop-timeout/bad.cpp
@@ -1,0 +1,32 @@
+namespace {
+class QObject {};
+
+class QEventLoop : public QObject {
+public:
+    void quit();
+    int exec();
+};
+
+class QTimer {
+public:
+    static void singleShot(int msec, const QObject *receiver, void (QEventLoop::*member)());
+};
+
+class Reply : public QObject {
+public:
+    void finished();
+    int result();
+};
+
+void connect(QObject*, void (Reply::*)(), QEventLoop*, void (QEventLoop::*)());
+void use(int);
+
+void launchWork(Reply* reply) {
+    QEventLoop loop;
+    QTimer::singleShot(2000, &loop, &QEventLoop::quit);
+    connect(reply, &Reply::finished, &loop, &QEventLoop::quit);
+    loop.exec();
+
+    use(reply->result());
+}
+}

--- a/tests/qt-kde-lint-ambiguous-qeventloop-timeout/good.cpp
+++ b/tests/qt-kde-lint-ambiguous-qeventloop-timeout/good.cpp
@@ -1,0 +1,40 @@
+namespace {
+class QObject {};
+
+class QEventLoop : public QObject {
+public:
+    void quit();
+    int exec();
+};
+
+class QTimer {
+public:
+    static void singleShot(int msec, const QObject *receiver, void (QEventLoop::*member)());
+};
+
+class Reply : public QObject {
+public:
+    void finished();
+    int result();
+};
+
+template <typename Func>
+void connect(QObject*, void (Reply::*)(), QEventLoop*, Func);
+
+void use(int);
+
+void launchWorkSafely(Reply* reply) {
+    QEventLoop loop;
+    bool finished = false;
+    QTimer::singleShot(2000, &loop, &QEventLoop::quit);
+    connect(reply, &Reply::finished, &loop, [&]() {
+        finished = true;
+        loop.quit();
+    });
+    loop.exec();
+
+    if (finished) {
+        use(reply->result());
+    }
+}
+}


### PR DESCRIPTION
Adds the `qt-kde-lint-ambiguous-qeventloop-timeout` rule according to issue #6.
The rule uses a structural heuristic to detect ambiguous QEventLoop timeouts combined with async signal connects. It checks if the sender result is used after in the same block.

---
*PR created automatically by Jules for task [13841653435574380595](https://jules.google.com/task/13841653435574380595) started by @arran4*