### PR TITLE
Add `qt-kde-lint-reject-id-in-createobject` QML rule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,18 @@ jobs:
       - name: Validate and generate rule configuration
         run: python3 tools/build_config.py --output build/.clang-tidy
 
+  declarative-qml-rules:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install tree-sitter tree-sitter-qmljs
+      - name: Test QML declarative rules
+        run: python3 tools/test_qml_rules.py
+
   declarative-rules:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           python-version: '3.x'
       - name: Install dependencies
-        run: pip install tree-sitter tree-sitter-qmljs
+        run: pip install -r requirements-qml.txt
       - name: Test QML declarative rules
         run: python3 tools/test_qml_rules.py
 

--- a/README.md
+++ b/README.md
@@ -36,11 +36,15 @@ See [`docs/RULE_AUTHORING.md`](docs/RULE_AUTHORING.md) for the contract.
 
 ## Local development
 
-LLVM/clang-tidy 23 or newer with query-based custom checks enabled is required.
+LLVM/clang-tidy 23 or newer with query-based custom checks enabled is required for C++ rules.
+
+For QML rules, Python 3 dependencies in `requirements-qml.txt` are required.
 
 ```sh
 python3 tools/build_config.py --output build/.clang-tidy
 python3 tools/test_rules.py --clang-tidy clang-tidy-23
+pip install -r requirements-qml.txt
+python3 tools/test_qml_rules.py
 ```
 
 Query-based custom checks currently require `--experimental-custom-checks`. The CI workflow pins the intended clang-tidy major rather than relying on the GitHub runner default.

--- a/README.md
+++ b/README.md
@@ -49,15 +49,15 @@ python3 tools/test_qml_rules.py
 
 ### Consumer Integration
 
-Downstream projects using `qt-kde-lint` should invoke both the C++ and QML lint passes.
+Downstream projects using `qt-kde-lint` should invoke both the C++ and QML lint passes. Check out this repository (e.g., into `.qt-kde-lint`) as part of your CI pipeline.
 
 For C++, use standard `clang-tidy` integration pointing to the generated `.clang-tidy` config.
 
-For QML, consumers must install the required parser dependencies and invoke `qml_linter.py` across their QML files as a merge-blocking step:
+For QML, consumers must install the required parser dependencies and invoke `qml_linter.py` across their QML files as a separate merge-blocking step:
 
 ```sh
-pip install -r qt-kde-lint/requirements-qml.txt
-find src -name "*.qml" -print0 | xargs -0 -r python3 qt-kde-lint/tools/qml_linter.py
+pip install -r .qt-kde-lint/requirements-qml.txt
+find src -name "*.qml" -print0 | xargs -0 -r python3 .qt-kde-lint/tools/qml_linter.py
 ```
 
 Query-based custom checks currently require `--experimental-custom-checks`. The CI workflow pins the intended clang-tidy major rather than relying on the GitHub runner default.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,19 @@ pip install -r requirements-qml.txt
 python3 tools/test_qml_rules.py
 ```
 
+### Consumer Integration
+
+Downstream projects using `qt-kde-lint` should invoke both the C++ and QML lint passes.
+
+For C++, use standard `clang-tidy` integration pointing to the generated `.clang-tidy` config.
+
+For QML, consumers must install the required parser dependencies and invoke `qml_linter.py` across their QML files as a merge-blocking step:
+
+```sh
+pip install -r qt-kde-lint/requirements-qml.txt
+find src -name "*.qml" -print0 | xargs -0 -r python3 qt-kde-lint/tools/qml_linter.py
+```
+
 Query-based custom checks currently require `--experimental-custom-checks`. The CI workflow pins the intended clang-tidy major rather than relying on the GitHub runner default.
 
 ## Status

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -1,0 +1,3 @@
+# Rule documentation
+
+Contains documentation for rules.

--- a/docs/rules/qt-kde-lint-reject-id-in-createobject.md
+++ b/docs/rules/qt-kde-lint-reject-id-in-createobject.md
@@ -1,0 +1,27 @@
+# qt-kde-lint-reject-id-in-createobject
+
+Detects QML/JavaScript code that tries to assign an `id` through the property map passed to `Component.createObject()`.
+
+## Problem
+
+Qt documents that dynamically-created QML objects do not have a QML `id`. The second argument to `createObject()` is a map of properties, and `id` is not a runtime QML property. Assigning it has no effect and often indicates a misunderstanding of object ownership and lifecycle in QML.
+
+Example of problematic code:
+```qml
+const menu = linkMenuComponent.createObject(parent, {
+    id: "linkMenu",
+    url: foundLink,
+});
+```
+
+## Solution
+
+Remove the `id` key. If you need to refer to the dynamically created instance later, retain the returned object reference in a JavaScript variable or a QML `property`.
+
+## Implementation Notes
+
+This rule is implemented in Python (`tools/qml_linter.py`) using `tree-sitter` and `tree-sitter-qmljs` to parse the QML AST.
+
+*Heuristic:* To avoid false positives on unrelated objects that happen to have a `createObject` method (like a custom `factory.createObject`), the linter employs a conservative heuristic: it only flags calls where the receiver's name ends in `Component` or `component` (e.g., `linkMenuComponent`, `component`).
+
+*Existing Tooling:* The standard `qmllint` (as of Qt 6) was tested and does **not** currently diagnose this issue. `qmllint` does not flag `id` within a property map passed to `createObject`, validating the need for this custom lint rule.

--- a/docs/rules/qt-kde-lint-reject-id-in-createobject.md
+++ b/docs/rules/qt-kde-lint-reject-id-in-createobject.md
@@ -22,6 +22,6 @@ Remove the `id` key. If you need to refer to the dynamically created instance la
 
 This rule is implemented in Python (`tools/qml_linter.py`) using `tree-sitter` and `tree-sitter-qmljs` to parse the QML AST.
 
-*Heuristic:* To avoid false positives on unrelated objects that happen to have a `createObject` method (like a custom `factory.createObject`), the linter employs a conservative heuristic: it only flags calls where the receiver's name ends in `Component` or `component` (e.g., `linkMenuComponent`, `component`).
+*Heuristic:* To avoid false positives on unrelated objects that happen to have a `createObject` method (like a custom `factory.createObject`), the linter employs a conservative two-pass AST collection strategy. First, it collects the IDs of all inline `Component { id: ... }` object definitions within the file. Then, it only flags `.createObject(...)` calls whose receiver resolves to one of those explicitly collected `Component` IDs. Uncertain or dynamic component-producing expressions are intentionally skipped to preserve the repository's precision-first policy.
 
-*Existing Tooling:* The standard `qmllint` (as of Qt 6) was tested and does **not** currently diagnose this issue. `qmllint` does not flag `id` within a property map passed to `createObject`, validating the need for this custom lint rule.
+*Existing Tooling:* `qmllint 1.0` (as distributed with Qt 6.4.2) was explicitly tested and does **not** currently diagnose this issue. `qmllint` does not flag `id` within a property map passed to `createObject`, validating the need for this custom lint rule.

--- a/requirements-qml.txt
+++ b/requirements-qml.txt
@@ -1,0 +1,2 @@
+tree-sitter>=0.21,<1.0
+tree-sitter-qmljs>=0.3.1,<1.0

--- a/tests/qml/qt-kde-lint-reject-id-in-createobject/bad-id-not-component.qml
+++ b/tests/qml/qt-kde-lint-reject-id-in-createobject/bad-id-not-component.qml
@@ -1,0 +1,14 @@
+import QtQuick
+
+Item {
+    id: root
+
+    Component {
+        id: maker
+        Item {}
+    }
+
+    Component.onCompleted: {
+        maker.createObject(parent, { id: "bad" });
+    }
+}

--- a/tests/qml/qt-kde-lint-reject-id-in-createobject/bad.qml
+++ b/tests/qml/qt-kde-lint-reject-id-in-createobject/bad.qml
@@ -1,0 +1,18 @@
+import QtQuick
+
+Item {
+    id: root
+
+    Component {
+        id: linkMenuComponent
+        Item {}
+    }
+
+    Component.onCompleted: {
+        const foundLink = "https://example.com"
+        const menu = linkMenuComponent.createObject(parent, {
+            id: "linkMenu",
+            url: foundLink,
+        });
+    }
+}

--- a/tests/qml/qt-kde-lint-reject-id-in-createobject/good-factory-component.qml
+++ b/tests/qml/qt-kde-lint-reject-id-in-createobject/good-factory-component.qml
@@ -1,0 +1,21 @@
+import QtQuick
+
+Item {
+    id: root
+
+    function doSomething() {
+        // This is a plain JavaScript object, not a QML Component
+        const factoryComponent = {
+            createObject: function(parent, props) {
+                return props;
+            }
+        };
+
+        const foundLink = "https://example.com"
+        // This should not trigger the linter even though its name contains Component
+        const record = factoryComponent.createObject(parent, {
+            id: "record",
+            url: foundLink,
+        });
+    }
+}

--- a/tests/qml/qt-kde-lint-reject-id-in-createobject/good-factory.qml
+++ b/tests/qml/qt-kde-lint-reject-id-in-createobject/good-factory.qml
@@ -1,0 +1,21 @@
+import QtQuick
+
+Item {
+    id: root
+
+    function doSomething() {
+        // This is a plain JavaScript object, not a QML Component
+        const factory = {
+            createObject: function(parent, props) {
+                return props;
+            }
+        };
+
+        const foundLink = "https://example.com"
+        // This should not trigger the linter
+        const record = factory.createObject(parent, {
+            id: "record",
+            url: foundLink,
+        });
+    }
+}

--- a/tests/qml/qt-kde-lint-reject-id-in-createobject/good-ordinary-id.qml
+++ b/tests/qml/qt-kde-lint-reject-id-in-createobject/good-ordinary-id.qml
@@ -1,0 +1,19 @@
+import QtQuick
+
+Item {
+    // Normal declarative ID should not trigger the rule
+    id: ordinaryIdFoo
+
+    Component {
+        id: linkMenuComponent
+        Item {}
+    }
+
+    Component.onCompleted: {
+        const foundLink = "https://example.com"
+        const menu = linkMenuComponent.createObject(parent, {
+            objectName: "linkMenu",
+            url: foundLink,
+        });
+    }
+}

--- a/tests/qml/qt-kde-lint-reject-id-in-createobject/good.qml
+++ b/tests/qml/qt-kde-lint-reject-id-in-createobject/good.qml
@@ -1,0 +1,18 @@
+import QtQuick
+
+Item {
+    id: root
+
+    Component {
+        id: linkMenuComponent
+        Item {}
+    }
+
+    Component.onCompleted: {
+        const foundLink = "https://example.com"
+        const menu = linkMenuComponent.createObject(parent, {
+            objectName: "linkMenu",
+            url: foundLink,
+        });
+    }
+}

--- a/tools/qml_linter.py
+++ b/tools/qml_linter.py
@@ -38,6 +38,29 @@ def check_qml(filepath):
                         break
 
                 if prop_ident and prop_ident.text == b'createObject':
+                    # Check receiver
+                    receiver = None
+                    for child in member_expr.children:
+                        if child.type == 'identifier':
+                            receiver = child
+                            break
+
+                    is_component = False
+                    if receiver:
+                        # Simplistic heuristic: assume it's a Component if its name ends with "Component" (case insensitive)
+                        # or if its name is exactly "component". This avoids false positives on things like `factory.createObject(...)`.
+                        # A better check would require resolving the identifier's type, but since we don't
+                        # have semantic analysis, this covers common patterns like `myComponent.createObject(...)`.
+                        receiver_name = receiver.text.lower()
+                        if receiver_name.endswith(b'component'):
+                            is_component = True
+
+                    if not is_component:
+                        # Skip if receiver doesn't look like a component
+                        for child in node.children:
+                            visit(child)
+                        return
+
                     # Now check arguments
                     args = None
                     for child in node.children:

--- a/tools/qml_linter.py
+++ b/tools/qml_linter.py
@@ -19,8 +19,45 @@ def check_qml(filepath):
     with open(filepath, 'rb') as f:
         tree = parser.parse(f.read())
 
+    known_components = set()
+
+    # Pass 1: Collect Component IDs
+    def collect_components(node):
+        if node.type == 'ui_object_definition':
+            # Check if this object is a Component
+            is_component_def = False
+            for child in node.children:
+                if child.type == 'identifier' and child.text == b'Component':
+                    is_component_def = True
+                    break
+
+            if is_component_def:
+                # Find its initializer block `{ ... }`
+                for child in node.children:
+                    if child.type == 'ui_object_initializer':
+                        # Look for an `id` binding
+                        for stmt in child.children:
+                            if stmt.type == 'ui_binding':
+                                key_node = None
+                                val_node = None
+                                for binding_child in stmt.children:
+                                    if binding_child.type == 'identifier':
+                                        key_node = binding_child
+                                    elif binding_child.type == 'expression_statement':
+                                        val_node = binding_child
+                                if key_node and key_node.text == b'id' and val_node:
+                                    # The id value is an identifier in the expression statement
+                                    for exp_child in val_node.children:
+                                        if exp_child.type == 'identifier':
+                                            known_components.add(exp_child.text)
+        for child in node.children:
+            collect_components(child)
+
+    collect_components(tree.root_node)
+
     issues = []
 
+    # Pass 2: Check createObject calls
     def visit(node):
         if node.type == 'call_expression':
             # Check if it's createObject
@@ -47,16 +84,12 @@ def check_qml(filepath):
 
                     is_component = False
                     if receiver:
-                        # Simplistic heuristic: assume it's a Component if its name ends with "Component" (case insensitive)
-                        # or if its name is exactly "component". This avoids false positives on things like `factory.createObject(...)`.
-                        # A better check would require resolving the identifier's type, but since we don't
-                        # have semantic analysis, this covers common patterns like `myComponent.createObject(...)`.
-                        receiver_name = receiver.text.lower()
-                        if receiver_name.endswith(b'component'):
+                        # Match if the receiver is a known Component ID
+                        if receiver.text in known_components:
                             is_component = True
 
                     if not is_component:
-                        # Skip if receiver doesn't look like a component
+                        # Skip if receiver doesn't resolve to a known component id
                         for child in node.children:
                             visit(child)
                         return

--- a/tools/qml_linter.py
+++ b/tools/qml_linter.py
@@ -1,0 +1,83 @@
+import sys
+import tree_sitter_qmljs
+from tree_sitter import Language, Parser
+
+import warnings
+
+def check_qml(filepath):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        try:
+            language = Language(tree_sitter_qmljs.language())
+        except Exception:
+            # Compatibility with older tree-sitter bindings
+            import tree_sitter
+            language = tree_sitter.Language(tree_sitter_qmljs.language(), "qmljs")
+
+    parser = Parser(language)
+
+    with open(filepath, 'rb') as f:
+        tree = parser.parse(f.read())
+
+    issues = []
+
+    def visit(node):
+        if node.type == 'call_expression':
+            # Check if it's createObject
+            member_expr = None
+            for child in node.children:
+                if child.type == 'member_expression':
+                    member_expr = child
+                    break
+
+            if member_expr:
+                prop_ident = None
+                for child in member_expr.children:
+                    if child.type == 'property_identifier':
+                        prop_ident = child
+                        break
+
+                if prop_ident and prop_ident.text == b'createObject':
+                    # Now check arguments
+                    args = None
+                    for child in node.children:
+                        if child.type == 'arguments':
+                            args = child
+                            break
+
+                    if args:
+                        for arg_child in args.children:
+                            if arg_child.type == 'object':
+                                # This is the properties object
+                                for obj_child in arg_child.children:
+                                    if obj_child.type == 'pair':
+                                        key_node = obj_child.children[0]
+                                        key_text = key_node.text
+                                        if key_node.type == 'string':
+                                            # Strip quotes
+                                            key_text = key_text.strip(b'"\'')
+                                        if key_node.type == 'property_identifier' or key_node.type == 'string':
+                                            if key_text == b'id':
+                                                issues.append(f"{filepath}:{node.start_point[0] + 1}: [custom-qt-kde-lint-reject-id-in-createobject] id is not a runtime QML property and cannot be assigned through Component.createObject(). Remove it; keep the returned object in a JavaScript/property reference if you need to refer to the instance.")
+
+        for child in node.children:
+            visit(child)
+
+    visit(tree.root_node)
+
+    return issues
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: qml_linter.py <file1.qml> ...")
+        sys.exit(1)
+
+    has_issues = False
+    for filepath in sys.argv[1:]:
+        issues = check_qml(filepath)
+        for issue in issues:
+            print(issue)
+            has_issues = True
+
+    if has_issues:
+        sys.exit(1)

--- a/tools/test_qml_rules.py
+++ b/tools/test_qml_rules.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Run positive and negative regression fixtures for every QML declarative rule."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from pathlib import Path
+
+
+def run_fixture(linter: Path, source: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            "python3",
+            str(linter),
+            str(source)
+        ],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+
+
+def fixtures(directory: Path, prefix: str) -> list[Path]:
+    return sorted(directory.glob(f"{prefix}*.qml"))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--linter", type=Path, default=Path("tools/qml_linter.py"))
+    parser.add_argument("--tests-dir", type=Path, default=Path("tests/qml"))
+    args = parser.parse_args()
+
+    if not args.tests_dir.exists():
+        print("no qml tests directory yet; rule harness is ready")
+        return 0
+
+    failures: list[str] = []
+
+    rules = [d.name for d in args.tests_dir.iterdir() if d.is_dir()]
+
+    if not rules:
+        print("no QML declarative rules yet; rule harness is ready")
+        return 0
+
+    for rule_name in rules:
+        marker = f"[custom-{rule_name}]"
+        rule_tests = args.tests_dir / rule_name
+        bad = fixtures(rule_tests, "bad")
+        good = fixtures(rule_tests, "good")
+
+        if not bad:
+            failures.append(f"{rule_name}: missing tests/qml/{rule_name}/bad*.qml fixture")
+        if not good:
+            failures.append(f"{rule_name}: missing tests/qml/{rule_name}/good*.qml fixture")
+        if not bad or not good:
+            continue
+
+        for source in bad:
+            result = run_fixture(args.linter, source)
+            if marker not in result.stdout:
+                failures.append(
+                    f"{rule_name}: {source} did not emit {marker}\n--- qml_linter output ---\n{result.stdout}"
+                )
+
+        for source in good:
+            result = run_fixture(args.linter, source)
+            if marker in result.stdout:
+                failures.append(
+                    f"{rule_name}: {source} unexpectedly emitted {marker}\n--- qml_linter output ---\n{result.stdout}"
+                )
+
+    if failures:
+        print("\n\n".join(failures))
+        return 1
+
+    print(f"all {len(rules)} QML declarative rule(s) passed regression tests")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/test_qml_rules.py
+++ b/tools/test_qml_rules.py
@@ -59,16 +59,16 @@ def main() -> int:
 
         for source in bad:
             result = run_fixture(args.linter, source)
-            if marker not in result.stdout:
+            if marker not in result.stdout or result.returncode == 0:
                 failures.append(
-                    f"{rule_name}: {source} did not emit {marker}\n--- qml_linter output ---\n{result.stdout}"
+                    f"{rule_name}: {source} did not emit {marker} or did not exit with error (exit code {result.returncode})\n--- qml_linter output ---\n{result.stdout}\n{result.stderr}"
                 )
 
         for source in good:
             result = run_fixture(args.linter, source)
-            if marker in result.stdout:
+            if marker in result.stdout or result.returncode != 0:
                 failures.append(
-                    f"{rule_name}: {source} unexpectedly emitted {marker}\n--- qml_linter output ---\n{result.stdout}"
+                    f"{rule_name}: {source} unexpectedly emitted {marker} or failed (exit code {result.returncode})\n--- qml_linter output ---\n{result.stdout}\n{result.stderr}"
                 )
 
     if failures:

--- a/tools/test_qml_rules.py
+++ b/tools/test_qml_rules.py
@@ -61,14 +61,14 @@ def main() -> int:
             result = run_fixture(args.linter, source)
             if marker not in result.stdout or result.returncode == 0:
                 failures.append(
-                    f"{rule_name}: {source} did not emit {marker} or did not exit with error (exit code {result.returncode})\n--- qml_linter output ---\n{result.stdout}\n{result.stderr}"
+                    f"{rule_name}: {source} did not emit {marker} or did not exit with error (exit code {result.returncode})\n--- qml_linter output ---\n{result.stdout}"
                 )
 
         for source in good:
             result = run_fixture(args.linter, source)
             if marker in result.stdout or result.returncode != 0:
                 failures.append(
-                    f"{rule_name}: {source} unexpectedly emitted {marker} or failed (exit code {result.returncode})\n--- qml_linter output ---\n{result.stdout}\n{result.stderr}"
+                    f"{rule_name}: {source} unexpectedly emitted {marker} or failed (exit code {result.returncode})\n--- qml_linter output ---\n{result.stdout}"
                 )
 
     if failures:


### PR DESCRIPTION
## Summary

Adds the `qt-kde-lint-reject-id-in-createobject` QML rule to detect attempts to pass `id` in the initial-properties map to `Component.createObject()`.

The PR introduces:

- a Python/tree-sitter QML lint path using `tree-sitter-qmljs`;
- conservative AST-backed receiver recognition by collecting actual inline `Component { id: ... }` declarations rather than relying on identifier naming;
- positive and negative QML regression fixtures, including adversarial receiver-name cases;
- repository CI coverage for QML declarative rules;
- bounded QML parser dependencies in `requirements-qml.txt`;
- rule documentation, including an explicit `qmllint 1.0` / Qt 6.4.2 comparison;
- local-development and downstream CI invocation guidance for the QML rule path;
- regression-harness validation of both diagnostic markers and process exit status.

Reviewed at `6b64c2b`; all repository CI jobs are green and the rule retains the project’s precision-first behavior by intentionally skipping uncertain/dynamic component-producing expressions.

Fixes #3

---
*PR created automatically by Jules for task [8985649024829683584](https://jules.google.com/task/8985649024829683584) started by @arran4*