### PR TITLE
Add rule for stack-allocated KXmlGuiWindow

### DIFF
--- a/rules/qt-kde-lint-kxmlguiwindow-stack-allocation.json
+++ b/rules/qt-kde-lint-kxmlguiwindow-stack-allocation.json
@@ -1,0 +1,11 @@
+{
+  "Name": "qt-kde-lint-kxmlguiwindow-stack-allocation",
+  "Query": "match varDecl(hasLocalStorage(), hasType(hasUnqualifiedDesugaredType(recordType(hasDeclaration(cxxRecordDecl(isDerivedFrom(hasAnyName(\"::KMainWindow\", \"::KXmlGuiWindow\"))))))), varDecl().bind(\"window\"), unless(hasDeclContext(decl(hasDescendant(cxxMemberCallExpr(on(declRefExpr(to(varDecl(equalsBoundNode(\"window\"))))), callee(cxxMethodDecl(hasName(\"setAttribute\"))), hasArgument(0, declRefExpr(to(enumConstantDecl(hasName(\"WA_DeleteOnClose\"))))), hasArgument(1, cxxBoolLiteral(equals(false)))))))))",
+  "Diagnostic": [
+    {
+      "BindName": "window",
+      "Message": "This KMainWindow/KXmlGuiWindow-derived object has automatic storage duration but normally deletes itself when closed. A close can therefore destroy the object before its C++ scope ends and cause a second destruction. Allocate it with an appropriate owner or explicitly disable WA_DeleteOnClose for this stack lifetime.",
+      "Level": "Warning"
+    }
+  ]
+}

--- a/tests/qt-kde-lint-kxmlguiwindow-stack-allocation/bad-2.cpp
+++ b/tests/qt-kde-lint-kxmlguiwindow-stack-allocation/bad-2.cpp
@@ -1,0 +1,19 @@
+namespace Qt {
+    enum WidgetAttribute {
+        WA_DeleteOnClose = 55
+    };
+}
+class QWidget {
+public:
+    void setAttribute(Qt::WidgetAttribute, bool on = true);
+    void show();
+};
+class KMainWindow : public QWidget {};
+
+class MainWin : public KMainWindow {};
+
+int main() {
+    MainWin win;
+    win.show();
+    return 0;
+}

--- a/tests/qt-kde-lint-kxmlguiwindow-stack-allocation/bad-3.cpp
+++ b/tests/qt-kde-lint-kxmlguiwindow-stack-allocation/bad-3.cpp
@@ -1,0 +1,22 @@
+namespace Qt {
+    enum WidgetAttribute {
+        WA_DeleteOnClose = 55
+    };
+}
+class QWidget {
+public:
+    void setAttribute(Qt::WidgetAttribute, bool on = true);
+    void show();
+};
+class KMainWindow : public QWidget {};
+class KXmlGuiWindow : public KMainWindow {};
+
+class MainWindow : public KXmlGuiWindow {};
+
+int main() {
+    MainWindow window;
+    MainWindow window2;
+    window2.setAttribute(Qt::WA_DeleteOnClose, false);
+    window.show();
+    return 0;
+}

--- a/tests/qt-kde-lint-kxmlguiwindow-stack-allocation/bad.cpp
+++ b/tests/qt-kde-lint-kxmlguiwindow-stack-allocation/bad.cpp
@@ -1,0 +1,20 @@
+namespace Qt {
+    enum WidgetAttribute {
+        WA_DeleteOnClose = 55
+    };
+}
+class QWidget {
+public:
+    void setAttribute(Qt::WidgetAttribute, bool on = true);
+    void show();
+};
+class KMainWindow : public QWidget {};
+class KXmlGuiWindow : public KMainWindow {};
+
+class MainWindow : public KXmlGuiWindow {};
+
+int main() {
+    MainWindow window;
+    window.show();
+    return 0;
+}

--- a/tests/qt-kde-lint-kxmlguiwindow-stack-allocation/good-2.cpp
+++ b/tests/qt-kde-lint-kxmlguiwindow-stack-allocation/good-2.cpp
@@ -1,0 +1,20 @@
+namespace Qt {
+    enum WidgetAttribute {
+        WA_DeleteOnClose = 55
+    };
+}
+class QWidget {
+public:
+    void setAttribute(Qt::WidgetAttribute, bool on = true);
+    void show();
+};
+class KMainWindow : public QWidget {};
+
+class MainWin : public KMainWindow {};
+
+int main() {
+    MainWin win;
+    win.setAttribute(Qt::WA_DeleteOnClose, false);
+    win.show();
+    return 0;
+}

--- a/tests/qt-kde-lint-kxmlguiwindow-stack-allocation/good-3.cpp
+++ b/tests/qt-kde-lint-kxmlguiwindow-stack-allocation/good-3.cpp
@@ -1,0 +1,19 @@
+namespace Qt {
+    enum WidgetAttribute {
+        WA_DeleteOnClose = 55
+    };
+}
+class QWidget {
+public:
+    void setAttribute(Qt::WidgetAttribute, bool on = true);
+    void show();
+};
+class KMainWindow : public QWidget {};
+class KXmlGuiWindow : public KMainWindow {};
+class MainWindow : public KXmlGuiWindow {};
+
+int main() {
+    MainWindow* window = new MainWindow;
+    window->show();
+    return 0;
+}

--- a/tests/qt-kde-lint-kxmlguiwindow-stack-allocation/good-4.cpp
+++ b/tests/qt-kde-lint-kxmlguiwindow-stack-allocation/good-4.cpp
@@ -1,0 +1,23 @@
+namespace Qt {
+    enum WidgetAttribute {
+        WA_DeleteOnClose = 55
+    };
+}
+class QWidget {
+public:
+    void setAttribute(Qt::WidgetAttribute, bool on = true);
+    void show();
+};
+class KMainWindow : public QWidget {};
+class KXmlGuiWindow : public KMainWindow {};
+
+class MainWindow : public KXmlGuiWindow {};
+
+int main() {
+    MainWindow window;
+    MainWindow window2;
+    window2.setAttribute(Qt::WA_DeleteOnClose, false);
+    window.setAttribute(Qt::WA_DeleteOnClose, false);
+    window.show();
+    return 0;
+}

--- a/tests/qt-kde-lint-kxmlguiwindow-stack-allocation/good.cpp
+++ b/tests/qt-kde-lint-kxmlguiwindow-stack-allocation/good.cpp
@@ -1,0 +1,21 @@
+namespace Qt {
+    enum WidgetAttribute {
+        WA_DeleteOnClose = 55
+    };
+}
+class QWidget {
+public:
+    void setAttribute(Qt::WidgetAttribute, bool on = true);
+    void show();
+};
+class KMainWindow : public QWidget {};
+class KXmlGuiWindow : public KMainWindow {};
+
+class MainWindow : public KXmlGuiWindow {};
+
+int main() {
+    MainWindow window;
+    window.setAttribute(Qt::WA_DeleteOnClose, false);
+    window.show();
+    return 0;
+}


### PR DESCRIPTION
Adds a new rule `qt-kde-lint-kxmlguiwindow-stack-allocation` to catch `KMainWindow` and `KXmlGuiWindow` derivatives allocated on the stack which might lead to a double-destruction bug.

---
*PR created automatically by Jules for task [2933606397995340188](https://jules.google.com/task/2933606397995340188) started by @arran4*