### PR TITLE
Add qt-kde-lint-gui-thread-blocking-wait rule

### DIFF
--- a/rules/qt-kde-lint-gui-thread-blocking-wait.json
+++ b/rules/qt-kde-lint-gui-thread-blocking-wait.json
@@ -1,0 +1,11 @@
+{
+  "Name": "qt-kde-lint-gui-thread-blocking-wait",
+  "Query": "match expr(anyOf(callExpr(callee(functionDecl(anyOf(hasName(\"::QThread::sleep\"), hasName(\"::QThread::msleep\"), hasName(\"::QThread::usleep\"))))), cxxMemberCallExpr(callee(cxxMethodDecl(hasName(\"exec\"), ofClass(hasName(\"::QEventLoop\")))))), hasAncestor(cxxMethodDecl(ofClass(isDerivedFrom(hasAnyName(\"::QWidget\", \"::QWindow\", \"::QDialog\", \"::QMainWindow\", \"::KMainWindow\", \"::KXmlGuiWindow\"))), unless(isStaticStorageClass())))).bind(\"problem\")",
+  "Diagnostic": [
+    {
+      "BindName": "problem",
+      "Message": "This blocking wait runs in a Qt GUI object method and prevents the event loop from processing input, repaint and queued events. Use asynchronous completion/timers or move the work to a worker thread instead of blocking the GUI thread.",
+      "Level": "Warning"
+    }
+  ]
+}

--- a/tests/qt-kde-lint-gui-thread-blocking-wait/bad.cpp
+++ b/tests/qt-kde-lint-gui-thread-blocking-wait/bad.cpp
@@ -1,0 +1,50 @@
+class QWidget {};
+class QWindow {};
+class QDialog : public QWidget {};
+class QMainWindow : public QWidget {};
+class KMainWindow : public QMainWindow {};
+class KXmlGuiWindow : public KMainWindow {};
+
+class QThread {
+public:
+    static void sleep(unsigned long);
+    static void msleep(unsigned long);
+    static void usleep(unsigned long);
+};
+class QEventLoop {
+public:
+    int exec(int flags = 0);
+};
+
+class MyWidget : public QWidget {
+public:
+    void bad() {
+        QThread::sleep(1);
+        QThread::msleep(2);
+        QThread::usleep(3);
+        QEventLoop loop;
+        loop.exec();
+    }
+};
+
+class MyWindow : public QWindow {
+public:
+    void bad() {
+        QThread::msleep(2);
+    }
+};
+
+class MyDialog : public QDialog {
+public:
+    void bad() {
+        QEventLoop loop;
+        loop.exec();
+    }
+};
+
+class MyMainWindow : public KXmlGuiWindow {
+public:
+    void bad() {
+        QThread::usleep(3);
+    }
+};

--- a/tests/qt-kde-lint-gui-thread-blocking-wait/good.cpp
+++ b/tests/qt-kde-lint-gui-thread-blocking-wait/good.cpp
@@ -1,0 +1,33 @@
+class QWidget {};
+class QWindow {};
+class QDialog : public QWidget {};
+class QMainWindow : public QWidget {};
+class KMainWindow : public QMainWindow {};
+class KXmlGuiWindow : public KMainWindow {};
+
+class QThread {
+public:
+    static void sleep(unsigned long);
+    static void msleep(unsigned long);
+    static void usleep(unsigned long);
+};
+class QEventLoop {
+public:
+    int exec(int flags = 0);
+};
+
+class MyWidget : public QWidget {
+public:
+    static void fine_static() {
+        QThread::sleep(1);
+    }
+};
+
+class NonWidget {
+public:
+    void fine_not_widget() {
+        QThread::sleep(1);
+        QEventLoop loop;
+        loop.exec();
+    }
+};


### PR DESCRIPTION
This adds a new rule `qt-kde-lint-gui-thread-blocking-wait` to detect synchronous blocking calls within UI thread classes. This addresses issue #15.

---
*PR created automatically by Jules for task [11992619703853930787](https://jules.google.com/task/11992619703853930787) started by @arran4*