### PR TITLE
Add lint rule for QList::contains() inside loops

### DIFF
--- a/rules/qt-kde-lint-qlist-contains-in-loop.json
+++ b/rules/qt-kde-lint-qlist-contains-in-loop.json
@@ -1,0 +1,11 @@
+{
+  "Name": "qt-kde-lint-qlist-contains-in-loop",
+  "Query": "match cxxMemberCallExpr(callee(cxxMethodDecl(hasName(\"contains\"), ofClass(hasName(\"QList\")))), on(expr(anyOf(declRefExpr(to(varDecl().bind(\"list\"))), memberExpr(member(fieldDecl().bind(\"listField\")))))), hasAncestor(anyOf(forStmt(), cxxForRangeStmt(), whileStmt(), doStmt())), hasAncestor(ifStmt(hasThen(anyOf(cxxMemberCallExpr(callee(cxxMethodDecl(anyOf(hasName(\"append\"), hasName(\"push_back\")), ofClass(hasName(\"QList\")))), on(expr(anyOf(declRefExpr(to(varDecl(equalsBoundNode(\"list\")))), memberExpr(member(fieldDecl(equalsBoundNode(\"listField\")))))))), cxxOperatorCallExpr(anyOf(hasOverloadedOperatorName(\"<<\"), hasOverloadedOperatorName(\"+=\")), hasArgument(0, expr(ignoringImpCasts(anyOf(declRefExpr(to(varDecl(equalsBoundNode(\"list\")))), memberExpr(member(fieldDecl(equalsBoundNode(\"listField\"))))))))), hasDescendant(cxxMemberCallExpr(callee(cxxMethodDecl(anyOf(hasName(\"append\"), hasName(\"push_back\")), ofClass(hasName(\"QList\")))), on(expr(anyOf(declRefExpr(to(varDecl(equalsBoundNode(\"list\")))), memberExpr(member(fieldDecl(equalsBoundNode(\"listField\"))))))))), hasDescendant(cxxOperatorCallExpr(anyOf(hasOverloadedOperatorName(\"<<\"), hasOverloadedOperatorName(\"+=\")), hasArgument(0, expr(ignoringImpCasts(anyOf(declRefExpr(to(varDecl(equalsBoundNode(\"list\")))), memberExpr(member(fieldDecl(equalsBoundNode(\"listField\"))))))))))))))).bind(\"problem\")",
+  "Diagnostic": [
+    {
+      "BindName": "problem",
+      "Message": "This loop performs a linear QList::contains() scan for each item while building/checking a set of unique values, making the operation quadratic. Use QSet membership or precompute an indexed representation when list ordering is not required.",
+      "Level": "Warning"
+    }
+  ]
+}

--- a/tests/qt-kde-lint-qlist-contains-in-loop/bad.cpp
+++ b/tests/qt-kde-lint-qlist-contains-in-loop/bad.cpp
@@ -1,0 +1,119 @@
+class QModelIndex {
+public:
+    int row() const { return 0; }
+};
+
+template <typename T>
+class QList {
+public:
+    bool contains(const T &value) const { return false; }
+    void append(const T &value) {}
+    void push_back(const T &value) {}
+    void operator<<(const T &value) {}
+    T* begin() { return nullptr; }
+    T* end() { return nullptr; }
+};
+
+template <typename T>
+class QSet {
+public:
+    bool contains(const T &value) const { return false; }
+    void insert(const T &value) {}
+};
+
+void test_bad_range_loop_append(QList<QModelIndex> indexes) {
+    QList<int> rows;
+    for (const QModelIndex &index : indexes) {
+        if (!rows.contains(index.row())) {
+            rows.append(index.row());
+        }
+    }
+}
+
+void test_bad_range_loop_push_back(QList<QModelIndex> indexes) {
+    QList<int> rows;
+    for (const QModelIndex &index : indexes) {
+        if (!rows.contains(index.row())) {
+            rows.push_back(index.row());
+        }
+    }
+}
+
+void test_bad_range_loop_operator(QList<QModelIndex> indexes) {
+    QList<int> rows;
+    for (const QModelIndex &index : indexes) {
+        if (!rows.contains(index.row())) {
+            rows << index.row();
+        }
+    }
+}
+
+void test_bad_range_loop_without_braces(QList<QModelIndex> indexes) {
+    QList<int> rows;
+    for (const QModelIndex &index : indexes) {
+        if (!rows.contains(index.row()))
+            rows.append(index.row());
+    }
+}
+
+void test_bad_for_loop() {
+    QList<int> rows;
+    for (int i = 0; i < 10; ++i) {
+        if (!rows.contains(i)) {
+            rows.append(i);
+        }
+    }
+}
+
+void test_bad_while_loop() {
+    QList<int> rows;
+    int i = 0;
+    while (i < 10) {
+        if (!rows.contains(i)) {
+            rows.append(i);
+        }
+        ++i;
+    }
+}
+
+void test_bad_do_while_loop() {
+    QList<int> rows;
+    int i = 0;
+    do {
+        if (!rows.contains(i)) {
+            rows.append(i);
+        }
+        ++i;
+    } while (i < 10);
+}
+
+struct TestField {
+    QList<int> rows;
+    void test_bad_field_range_loop(QList<QModelIndex> indexes) {
+        for (const QModelIndex &index : indexes) {
+            if (!rows.contains(index.row())) {
+                rows.append(index.row());
+            }
+        }
+    }
+};
+
+struct TestThisField {
+    QList<int> rows;
+    void test_bad_this_field_range_loop(QList<QModelIndex> indexes) {
+        for (const QModelIndex &index : indexes) {
+            if (!this->rows.contains(index.row())) {
+                this->rows.append(index.row());
+            }
+        }
+    }
+};
+
+void test_bad_range_loop_operator_plus_equal(QList<QModelIndex> indexes) {
+    QList<int> rows;
+    for (const QModelIndex &index : indexes) {
+        if (!rows.contains(index.row())) {
+            rows += index.row();
+        }
+    }
+}

--- a/tests/qt-kde-lint-qlist-contains-in-loop/good.cpp
+++ b/tests/qt-kde-lint-qlist-contains-in-loop/good.cpp
@@ -1,0 +1,91 @@
+class QModelIndex {
+public:
+    int row() const { return 0; }
+};
+
+template <typename T>
+class QList {
+public:
+    bool contains(const T &value) const { return false; }
+    void append(const T &value) {}
+    void push_back(const T &value) {}
+    void operator<<(const T &value) {}
+    T* begin() { return nullptr; }
+    T* end() { return nullptr; }
+};
+
+template <typename T>
+class QSet {
+public:
+    bool contains(const T &value) const { return false; }
+    void insert(const T &value) {}
+};
+
+void test_good_qset_insert(QList<QModelIndex> indexes) {
+    QSet<int> rows;
+    for (const QModelIndex &index : indexes) {
+        rows.insert(index.row());
+    }
+}
+
+void test_good_different_lists() {
+    QList<int> a;
+    QList<int> b;
+    for (int i = 0; i < 10; ++i) {
+        if (!a.contains(i)) {
+            b.append(i);
+        }
+    }
+}
+
+void test_good_no_loop() {
+    QList<int> rows;
+    if (!rows.contains(1)) {
+        rows.append(1);
+    }
+}
+
+void test_good_just_contains() {
+    QList<int> rows;
+    for (int i = 0; i < 10; ++i) {
+        if (!rows.contains(i)) {
+            // do nothing
+        }
+    }
+}
+
+struct TestFieldGood {
+    QList<int> a;
+    QList<int> b;
+    void test_good_different_fields() {
+        for (int i = 0; i < 10; ++i) {
+            if (!a.contains(i)) {
+                b.append(i);
+            }
+        }
+    }
+};
+
+struct TestMix {
+    QList<int> a;
+    void test_good_mix() {
+        QList<int> b;
+        for (int i = 0; i < 10; ++i) {
+            if (!a.contains(i)) {
+                b.append(i);
+            }
+        }
+    }
+};
+
+struct TestMix2 {
+    QList<int> a;
+    void test_good_mix2() {
+        QList<int> b;
+        for (int i = 0; i < 10; ++i) {
+            if (!b.contains(i)) {
+                a.append(i);
+            }
+        }
+    }
+};


### PR DESCRIPTION
Added a declarative lint rule (`qt-kde-lint-qlist-contains-in-loop`) which catches inefficient usage of `QList::contains()` checks for uniqueness directly inside a loop, followed by appending an element onto that very same list. Includes regression fixtures.

---
*PR created automatically by Jules for task [3337670843172346953](https://jules.google.com/task/3337670843172346953) started by @arran4*