### PR TITLE
Add qt-kde-lint-qmodelindex-deferred-capture rule

### DIFF
--- a/rules/qt-kde-lint-qmodelindex-deferred-capture.json
+++ b/rules/qt-kde-lint-qmodelindex-deferred-capture.json
@@ -1,0 +1,11 @@
+{
+  "Name": "qt-kde-lint-qmodelindex-deferred-capture",
+  "Query": "match lambdaExpr(hasAnyCapture(lambdaCapture(capturesVar(varDecl(anyOf(hasType(hasUnqualifiedDesugaredType(recordType(hasDeclaration(recordDecl(hasName(\"::QModelIndex\")))))), hasType(references(hasUnqualifiedDesugaredType(recordType(hasDeclaration(recordDecl(hasName(\"::QModelIndex\"))))))))).bind(\"capture\")))), hasAncestor(callExpr(callee(functionDecl(hasAnyName(\"::QObject::connect\", \"::QTimer::singleShot\", \"connect\", \"singleShot\")))))).bind(\"lambda\")",
+  "Diagnostic": [
+    {
+      "BindName": "lambda",
+      "Message": "This QModelIndex is captured for deferred use after control returns to the event loop. Ordinary model changes can invalidate a QModelIndex before the action runs. Capture a QPersistentModelIndex (and still check isValid() at use time) when the operation is meant to follow the same model item.",
+      "Level": "Warning"
+    }
+  ]
+}

--- a/tests/qt-kde-lint-qmodelindex-deferred-capture/bad.cpp
+++ b/tests/qt-kde-lint-qmodelindex-deferred-capture/bad.cpp
@@ -1,0 +1,30 @@
+class QModelIndex {};
+class QTimer {
+public:
+    template <typename Func>
+    static void singleShot(int msec, Func slot) {}
+};
+
+struct QAction {};
+struct QObject {
+    template <typename Func>
+    static void connect(QAction* sender, void* signal, void* context, Func slot) {}
+};
+
+void testAction(QAction* action, QModelIndex index) {
+    QObject::connect(action, nullptr, nullptr, [index]() {
+        // use index
+    });
+}
+
+void testTimer(QModelIndex index) {
+    QTimer::singleShot(0, [index]() {
+        // use index
+    });
+}
+
+void testActionRef(QAction* action, const QModelIndex& index) {
+    QObject::connect(action, nullptr, nullptr, [index]() {
+        // use index
+    });
+}

--- a/tests/qt-kde-lint-qmodelindex-deferred-capture/good.cpp
+++ b/tests/qt-kde-lint-qmodelindex-deferred-capture/good.cpp
@@ -1,0 +1,30 @@
+class QModelIndex {};
+class QPersistentModelIndex {
+public:
+    QPersistentModelIndex(QModelIndex);
+};
+class QTimer {
+public:
+    template <typename Func>
+    static void singleShot(int msec, Func slot) {}
+};
+
+struct QAction {};
+struct QObject {
+    template <typename Func>
+    static void connect(QAction* sender, void* signal, void* context, Func slot) {}
+};
+
+void testAction(QAction* action, QModelIndex index) {
+    QPersistentModelIndex pIndex(index);
+    QObject::connect(action, nullptr, nullptr, [pIndex]() {
+        // use pIndex
+    });
+}
+
+void testTimer(QModelIndex index) {
+    QPersistentModelIndex pIndex(index);
+    QTimer::singleShot(0, [pIndex]() {
+        // use pIndex
+    });
+}


### PR DESCRIPTION
Closes #22 by adding a new clang-tidy custom rule `qt-kde-lint-qmodelindex-deferred-capture`.

---
*PR created automatically by Jules for task [14855613329109700858](https://jules.google.com/task/14855613329109700858) started by @arran4*