### PR TITLE
Add lint rule for stable objectName on state-saved QToolBar and QDockWidget

### DIFF
--- a/rules/qt-kde-lint-qmainwindow-stable-objectname.json
+++ b/rules/qt-kde-lint-qmainwindow-stable-objectname.json
@@ -1,0 +1,11 @@
+{
+  "Name": "qt-kde-lint-qmainwindow-stable-objectname",
+  "Query": "match expr(anyOf(cxxMemberCallExpr(callee(cxxMethodDecl(hasName(\"addToolBar\"), returns(pointerType(pointee(hasDeclaration(cxxRecordDecl(hasName(\"QToolBar\"))))))))), cxxNewExpr(hasType(pointerType(pointee(hasDeclaration(cxxRecordDecl(hasName(\"QDockWidget\")))))))), anyOf(hasAncestor(cxxRecordDecl(anyOf(isDerivedFrom(hasName(\"KMainWindow\")), isDerivedFrom(hasName(\"KXmlGuiWindow\")), hasDescendant(cxxMemberCallExpr(callee(cxxMethodDecl(anyOf(hasName(\"saveState\"), hasName(\"restoreState\"))))))))), hasAncestor(functionDecl(hasDescendant(cxxMemberCallExpr(callee(cxxMethodDecl(anyOf(hasName(\"saveState\"), hasName(\"restoreState\"))))))))), unless(hasAncestor(varDecl(varDecl().bind(\"name\"), hasAncestor(compoundStmt(hasDescendant(cxxMemberCallExpr(callee(cxxMethodDecl(hasName(\"setObjectName\"))), on(ignoringParenImpCasts(declRefExpr(to(varDecl(equalsBoundNode(\"name\"))))))))))))), unless(hasAncestor(cxxMemberCallExpr(callee(cxxMethodDecl(hasName(\"setObjectName\")))))), unless(hasAncestor(binaryOperator(isAssignmentOperator(), hasLHS(ignoringParenImpCasts(memberExpr(member(fieldDecl().bind(\"member_name\"))))), hasAncestor(compoundStmt(hasDescendant(cxxMemberCallExpr(callee(cxxMethodDecl(hasName(\"setObjectName\"))), on(ignoringParenImpCasts(memberExpr(member(fieldDecl(equalsBoundNode(\"member_name\")))))))))))))).bind(\"bad_expr\")",
+  "Diagnostic": [
+    {
+      "BindName": "bad_expr",
+      "Message": "This QToolBar or QDockWidget participates in QMainWindow state persistence but has no stable objectName. saveState()/restoreState() cannot reliably identify it; assign a deterministic, untranslated object name before restoring or saving window state.",
+      "Level": "Warning"
+    }
+  ]
+}

--- a/tests/qt-kde-lint-qmainwindow-stable-objectname/bad.cpp
+++ b/tests/qt-kde-lint-qmainwindow-stable-objectname/bad.cpp
@@ -1,0 +1,85 @@
+class QString {
+public:
+    QString(const char*);
+};
+
+class QObject {
+public:
+    void setObjectName(const QString&);
+};
+
+
+class QWidget : public QObject {};
+class QMainWindow : public QWidget {
+public:
+    class QToolBar* addToolBar(const QString &title);
+    void addToolBar(class QToolBar*);
+    void addDockWidget(int, class QDockWidget*);
+    void saveState();
+    void restoreState();
+};
+
+class KMainWindow : public QMainWindow {};
+class KXmlGuiWindow : public KMainWindow {};
+
+class QToolBar : public QWidget {
+public:
+    QToolBar(const QString& title, QWidget *parent = nullptr);
+    void setObjectName(const QString&);
+};
+
+class QDockWidget : public QWidget {
+public:
+    QDockWidget(const QString& title, QWidget *parent = nullptr);
+    void setObjectName(const QString&);
+};
+
+class BadKMainWindow : public KMainWindow {
+public:
+    BadKMainWindow() {
+        auto *toolbar = addToolBar("Main"); // BAD
+
+        auto *dock = new QDockWidget("Dock"); // BAD
+        addDockWidget(1, dock);
+    }
+};
+
+class BadNormalWindow : public QMainWindow {
+public:
+    BadNormalWindow() {
+        auto *toolbar = addToolBar("Main"); // BAD
+        saveState();
+    }
+};
+
+class DirectWindow : public KXmlGuiWindow {
+public:
+    DirectWindow() {
+        addToolBar("BadDirect"); // BAD
+    }
+};
+
+void local_test() {
+    QMainWindow w;
+    auto t = w.addToolBar("Test"); // BAD
+    w.saveState();
+}
+
+class RestoreWindow : public QMainWindow {
+public:
+    RestoreWindow() {
+        auto *toolbar = addToolBar("Main"); // BAD
+        restoreState();
+    }
+};
+
+class MemberBadWindow : public KMainWindow {
+public:
+    MemberBadWindow() {
+        this->m_toolbar = addToolBar("Main2"); // BAD
+        m_dock = new QDockWidget("Dock2"); // BAD
+    }
+private:
+    QToolBar* m_toolbar;
+    QDockWidget* m_dock;
+};

--- a/tests/qt-kde-lint-qmainwindow-stable-objectname/good.cpp
+++ b/tests/qt-kde-lint-qmainwindow-stable-objectname/good.cpp
@@ -1,0 +1,92 @@
+class QString {
+public:
+    QString(const char*);
+};
+
+class QObject {
+public:
+    void setObjectName(const QString&);
+};
+
+
+class QWidget : public QObject {};
+class QMainWindow : public QWidget {
+public:
+    class QToolBar* addToolBar(const QString &title);
+    void addToolBar(class QToolBar*);
+    void addDockWidget(int, class QDockWidget*);
+    void saveState();
+    void restoreState();
+};
+
+class KMainWindow : public QMainWindow {};
+class KXmlGuiWindow : public KMainWindow {};
+
+class QToolBar : public QWidget {
+public:
+    QToolBar(const QString& title, QWidget *parent = nullptr);
+    void setObjectName(const QString&);
+};
+
+class QDockWidget : public QWidget {
+public:
+    QDockWidget(const QString& title, QWidget *parent = nullptr);
+    void setObjectName(const QString&);
+};
+
+class GoodKMainWindow : public KMainWindow {
+public:
+    GoodKMainWindow() {
+        auto *toolbar = addToolBar("Main"); // GOOD
+        toolbar->setObjectName("MainToolBar");
+
+        auto *dock = new QDockWidget("Dock"); // GOOD
+        dock->setObjectName("MainDock");
+        addDockWidget(1, dock);
+    }
+};
+
+class GoodNormalWindow : public QMainWindow {
+public:
+    GoodNormalWindow() {
+        auto *toolbar = addToolBar("Main"); // GOOD, doesn't save state
+    }
+};
+
+class GoodDirectWindow : public KXmlGuiWindow {
+public:
+    GoodDirectWindow() {
+        addToolBar("GoodDirect")->setObjectName("OK"); // GOOD
+    }
+};
+
+void local_test_good() {
+    QMainWindow w;
+    auto t = w.addToolBar("Test"); // GOOD
+    t->setObjectName("TestBar");
+    w.saveState();
+}
+
+class MemberGoodWindow : public QMainWindow {
+public:
+    MemberGoodWindow() {
+        this->m_toolbar = addToolBar("Main2"); // GOOD
+        this->m_toolbar->setObjectName("MainToolBar2");
+
+        m_toolbar_no_this = addToolBar("Main3"); // GOOD
+        m_toolbar_no_this->setObjectName("MainToolBar3");
+    }
+    void saveState();
+private:
+    QToolBar* m_toolbar;
+    QToolBar* m_toolbar_no_this;
+};
+
+class IgnoreExistingToolbar : public KMainWindow {
+public:
+    IgnoreExistingToolbar() {
+        QToolBar* existing = new QToolBar("Exist"); // GOOD (not a dockwidget or returned addToolBar)
+        addToolBar(existing);
+        existing->setObjectName("ExistBar");
+    }
+};


### PR DESCRIPTION
Adds a new declarative lint rule to enforce setting stable `objectName`s for UI elements participating in window state serialization, fulfilling issue #20.

The new rule targets `addToolBar(const QString&)` and `new QDockWidget(...)` creations when they exist within a class inheriting from `KMainWindow`/`KXmlGuiWindow` or in a scope explicitly containing `saveState()` / `restoreState()`. It explicitly checks for subsequent `setObjectName()` calls to avoid false positives. 

Added regression tests `tests/qt-kde-lint-qmainwindow-stable-objectname/good.cpp` and `bad.cpp` with edge cases handling member variables, bound variables, and implicit `this->` accesses.

---
*PR created automatically by Jules for task [8166447695302350492](https://jules.google.com/task/8166447695302350492) started by @arran4*