### PR TITLE
Add qt-kde-lint-qsystemtrayicon-short-lived-menu rule

### DIFF
--- a/rules/qt-kde-lint-qsystemtrayicon-short-lived-menu.json
+++ b/rules/qt-kde-lint-qsystemtrayicon-short-lived-menu.json
@@ -1,0 +1,11 @@
+{
+  "Name": "qt-kde-lint-qsystemtrayicon-short-lived-menu",
+  "Query": "match cxxMemberCallExpr(callee(cxxMethodDecl(hasName(\"setContextMenu\"), ofClass(hasName(\"QSystemTrayIcon\")))), hasArgument(0, expr(ignoringImpCasts(ignoringParenCasts(anyOf(unaryOperator(hasOperatorName(\"&\"), hasUnaryOperand(ignoringParenCasts(declRefExpr(to(varDecl(hasLocalStorage())))))), cxxMemberCallExpr(callee(cxxMethodDecl(hasName(\"get\"), ofClass(hasAnyName(\"::std::unique_ptr\", \"::QScopedPointer\", \"unique_ptr\", \"QScopedPointer\")))), on(expr(ignoringParenCasts(declRefExpr(to(varDecl(hasLocalStorage()))))))))))))).bind(\"problem\")",
+  "Diagnostic": [
+    {
+      "BindName": "problem",
+      "Message": "QSystemTrayIcon does not take ownership of its context menu, but this menu has shorter storage duration than the tray icon. Keep the QMenu alive (for example as a suitably-parented/member object) for as long as the tray icon can request it.",
+      "Level": "Warning"
+    }
+  ]
+}

--- a/tests/qt-kde-lint-qsystemtrayicon-short-lived-menu/bad.cpp
+++ b/tests/qt-kde-lint-qsystemtrayicon-short-lived-menu/bad.cpp
@@ -1,0 +1,42 @@
+namespace std {
+template <typename T> class unique_ptr {
+public:
+    T* get() const { return ptr; }
+    T* ptr;
+};
+}
+
+template <typename T> class QScopedPointer {
+public:
+    T* get() const { return ptr; }
+    T* ptr;
+};
+
+class QMenu {
+public:
+    QMenu();
+};
+
+class QSystemTrayIcon {
+public:
+    QSystemTrayIcon();
+    void setContextMenu(QMenu *menu);
+};
+
+void test_local_stack() {
+    QMenu menu;
+    QSystemTrayIcon trayIcon;
+    trayIcon.setContextMenu(&menu);
+}
+
+void test_unique_ptr() {
+    std::unique_ptr<QMenu> menu;
+    QSystemTrayIcon trayIcon;
+    trayIcon.setContextMenu(menu.get());
+}
+
+void test_scoped_pointer() {
+    QScopedPointer<QMenu> menu;
+    QSystemTrayIcon trayIcon;
+    trayIcon.setContextMenu(menu.get());
+}

--- a/tests/qt-kde-lint-qsystemtrayicon-short-lived-menu/good.cpp
+++ b/tests/qt-kde-lint-qsystemtrayicon-short-lived-menu/good.cpp
@@ -1,0 +1,50 @@
+namespace std {
+template <typename T> class unique_ptr {
+public:
+    T* get() const { return ptr; }
+    T* ptr;
+};
+}
+
+template <typename T> class QScopedPointer {
+public:
+    T* get() const { return ptr; }
+    T* ptr;
+};
+
+class QMenu {
+public:
+    QMenu();
+};
+
+class QSystemTrayIcon {
+public:
+    QSystemTrayIcon();
+    void setContextMenu(QMenu *menu);
+};
+
+class MyTray {
+    QMenu menu;
+    std::unique_ptr<QMenu> menu_ptr;
+    QSystemTrayIcon tray;
+
+public:
+    void setup1() {
+        tray.setContextMenu(&menu);
+    }
+    void setup2() {
+        tray.setContextMenu(menu_ptr.get());
+    }
+};
+
+void test_heap() {
+    QMenu *menu = new QMenu();
+    QSystemTrayIcon trayIcon;
+    trayIcon.setContextMenu(menu);
+}
+
+void test_global() {
+    static QMenu global_menu;
+    QSystemTrayIcon trayIcon;
+    trayIcon.setContextMenu(&global_menu);
+}


### PR DESCRIPTION
This PR adds a new static analysis lint rule `qt-kde-lint-qsystemtrayicon-short-lived-menu` to detect passing a short-lived `QMenu` object to `QSystemTrayIcon::setContextMenu()`.

As noted in the Qt documentation, `QSystemTrayIcon` does not take ownership of the context menu. Passing a local stack variable or a local smart pointer leads to a dangling pointer once the function returns, causing crashes or missing context menus.

The clang-query matcher reliably flags:
*   Local stack menus passed by address (`&menu`).
*   Local smart pointers (`std::unique_ptr` and `QScopedPointer`) when their `.get()` method is called.

The rule ignores valid configurations, such as heap allocations (via `new`), class members, or static globals.

Resolves #24.

---
*PR created automatically by Jules for task [13483998436810752088](https://jules.google.com/task/13483998436810752088) started by @arran4*