### PR TITLE
feat: Add rule qt-kde-lint-qsystemtrayicon-redundant-context-menu

### DIFF
--- a/rules/qt-kde-lint-qsystemtrayicon-redundant-context-menu.json
+++ b/rules/qt-kde-lint-qsystemtrayicon-redundant-context-menu.json
@@ -1,0 +1,11 @@
+{
+  "Name": "qt-kde-lint-qsystemtrayicon-redundant-context-menu",
+  "Query": "match compoundStmt(hasDescendant(cxxMemberCallExpr(callee(cxxMethodDecl(hasName(\"setContextMenu\"))), on(declRefExpr(to(varDecl(hasType(pointerType(pointee(hasDeclaration(cxxRecordDecl(hasName(\"QSystemTrayIcon\"))))))).bind(\"tray_icon\")))), hasArgument(0, expr(ignoringParenImpCasts(declRefExpr(to(varDecl().bind(\"tray_menu\")))))))), hasDescendant(callExpr(callee(functionDecl(hasName(\"connect\"))), hasArgument(0, expr(ignoringParenImpCasts(declRefExpr(to(varDecl(equalsBoundNode(\"tray_icon\"))))))), hasAnyArgument(expr(ignoringImpCasts(lambdaExpr(hasDescendant(anyOf(ifStmt(hasCondition(expr(hasDescendant(declRefExpr(to(enumConstantDecl(hasName(\"Context\"))))))), hasThen(anyOf(cxxMemberCallExpr(callee(cxxMethodDecl(anyOf(hasName(\"popup\"), hasName(\"exec\")))), on(declRefExpr(to(varDecl(equalsBoundNode(\"tray_menu\")))))).bind(\"popup_call\"), stmt(hasDescendant(cxxMemberCallExpr(callee(cxxMethodDecl(anyOf(hasName(\"popup\"), hasName(\"exec\")))), on(declRefExpr(to(varDecl(equalsBoundNode(\"tray_menu\")))))).bind(\"popup_call\")))))), switchStmt(hasDescendant(caseStmt(hasDescendant(declRefExpr(to(enumConstantDecl(hasName(\"Context\"))))), hasDescendant(cxxMemberCallExpr(callee(cxxMethodDecl(anyOf(hasName(\"popup\"), hasName(\"exec\")))), on(declRefExpr(to(varDecl(equalsBoundNode(\"tray_menu\")))))).bind(\"popup_call\"))))))))))))))",
+  "Diagnostic": [
+    {
+      "BindName": "popup_call",
+      "Message": "This QSystemTrayIcon already has a context menu installed with setContextMenu(), which Qt opens when Context is requested. Manually calling popup()/exec() for the same menu can double-handle the request and conflict with the native tray host; remove the manual popup and let QSystemTrayIcon present the menu.",
+      "Level": "Warning"
+    }
+  ]
+}

--- a/tests/qt-kde-lint-qsystemtrayicon-redundant-context-menu/bad.cpp
+++ b/tests/qt-kde-lint-qsystemtrayicon-redundant-context-menu/bad.cpp
@@ -1,0 +1,66 @@
+class QObject {};
+
+class QMenu {
+public:
+    void popup(int pos) {}
+    void exec() {}
+};
+
+class QCursor {
+public:
+    static int pos() { return 0; }
+};
+
+class QSystemTrayIcon : public QObject {
+public:
+    enum ActivationReason {
+        Unknown,
+        Context,
+        DoubleClick,
+        Trigger,
+        MiddleClick
+    };
+    void setContextMenu(class QMenu* menu) {}
+    void activated(ActivationReason reason) {}
+};
+
+class MyClass : public QObject {
+public:
+    template <typename Func1, typename Func2>
+    static void connect(const QObject *sender, Func1 signal, const QObject *receiver, Func2 slot) {}
+
+    template <typename Func1, typename Func2>
+    static void connect(const QObject *sender, Func1 signal, Func2 slot) {}
+
+    void setupTray() {
+        QSystemTrayIcon* trayIcon = new QSystemTrayIcon();
+        QMenu* trayMenu = new QMenu();
+
+        trayIcon->setContextMenu(trayMenu);
+
+        connect(trayIcon, 0, this,
+                [trayMenu](QSystemTrayIcon::ActivationReason reason) {
+                    if (reason == QSystemTrayIcon::Context) {
+                        trayMenu->popup(QCursor::pos());
+                    }
+                });
+    }
+
+    void setupTray2() {
+        QSystemTrayIcon* trayIcon = new QSystemTrayIcon();
+        QMenu* trayMenu = new QMenu();
+
+        trayIcon->setContextMenu(trayMenu);
+
+        connect(trayIcon, 0, this,
+                [trayMenu](QSystemTrayIcon::ActivationReason reason) {
+                    switch (reason) {
+                        case QSystemTrayIcon::Context:
+                            trayMenu->exec();
+                            break;
+                        default:
+                            break;
+                    }
+                });
+    }
+};

--- a/tests/qt-kde-lint-qsystemtrayicon-redundant-context-menu/good.cpp
+++ b/tests/qt-kde-lint-qsystemtrayicon-redundant-context-menu/good.cpp
@@ -1,0 +1,75 @@
+class QObject {};
+
+class QMenu {
+public:
+    void popup(int pos) {}
+    void exec() {}
+};
+
+class QCursor {
+public:
+    static int pos() { return 0; }
+};
+
+class QSystemTrayIcon : public QObject {
+public:
+    enum ActivationReason {
+        Unknown,
+        Context,
+        DoubleClick,
+        Trigger,
+        MiddleClick
+    };
+    void setContextMenu(class QMenu* menu) {}
+    void activated(ActivationReason reason) {}
+};
+
+class MyClass : public QObject {
+public:
+    template <typename Func1, typename Func2>
+    static void connect(const QObject *sender, Func1 signal, const QObject *receiver, Func2 slot) {}
+
+    template <typename Func1, typename Func2>
+    static void connect(const QObject *sender, Func1 signal, Func2 slot) {}
+
+    void setupTray() {
+        QSystemTrayIcon* trayIcon = new QSystemTrayIcon();
+        QMenu* trayMenu = new QMenu();
+        QMenu* otherMenu = new QMenu();
+
+        trayIcon->setContextMenu(trayMenu);
+
+        connect(trayIcon, 0, this,
+                [otherMenu](QSystemTrayIcon::ActivationReason reason) {
+                    if (reason == QSystemTrayIcon::Context) {
+                        otherMenu->popup(QCursor::pos());
+                    }
+                });
+    }
+
+    void setupTray2() {
+        QSystemTrayIcon* trayIcon = new QSystemTrayIcon();
+        QMenu* trayMenu = new QMenu();
+
+        connect(trayIcon, 0, this,
+                [trayMenu](QSystemTrayIcon::ActivationReason reason) {
+                    if (reason == QSystemTrayIcon::Context) {
+                        trayMenu->popup(QCursor::pos());
+                    }
+                });
+    }
+
+    void setupTray3() {
+        QSystemTrayIcon* trayIcon = new QSystemTrayIcon();
+        QMenu* trayMenu = new QMenu();
+
+        trayIcon->setContextMenu(trayMenu);
+
+        connect(trayIcon, 0, this,
+                [trayMenu](QSystemTrayIcon::ActivationReason reason) {
+                    if (reason == QSystemTrayIcon::Trigger) {
+                        trayMenu->popup(QCursor::pos());
+                    }
+                });
+    }
+};


### PR DESCRIPTION
This adds a declarative clang-tidy custom rule that detects cases where a `QSystemTrayIcon` has a menu set via `setContextMenu()` but also has an `activated` signal handler that manually intercepts the `Context` activation reason and calls `popup()` or `exec()` on that same menu.

This double-handling is redundant and can conflict with native tray hosts.

Fixes #25.

---
*PR created automatically by Jules for task [5646165355722887078](https://jules.google.com/task/5646165355722887078) started by @arran4*