### PR TITLE
feat: Add rule to detect manual deletion of QPluginLoader instance

### DIFF
--- a/rules/qt-kde-lint-qpluginloader-instance-delete.json
+++ b/rules/qt-kde-lint-qpluginloader-instance-delete.json
@@ -1,0 +1,11 @@
+{
+  "Name": "qt-kde-lint-qpluginloader-instance-delete",
+  "Query": "match expr( anyOf( cxxDeleteExpr( has( expr( anyOf( ignoringParenImpCasts( declRefExpr( to( varDecl( hasInitializer( expr( anyOf( ignoringParenImpCasts( cxxMemberCallExpr( callee( cxxMethodDecl( hasName(\"instance\"), ofClass( hasName(\"QPluginLoader\") ) ) ) ) ), ignoringParenImpCasts( castExpr( hasSourceExpression( ignoringParenImpCasts( cxxMemberCallExpr( callee( cxxMethodDecl( hasName(\"instance\"), ofClass( hasName(\"QPluginLoader\") ) ) ) ) ) ) ) ), ignoringParenImpCasts( callExpr( callee( functionDecl( hasName(\"qobject_cast\") ) ), hasArgument( 0, ignoringParenImpCasts( cxxMemberCallExpr( callee( cxxMethodDecl( hasName(\"instance\"), ofClass( hasName(\"QPluginLoader\") ) ) ) ) ) ) ) ) ) ) ) ) ) ) ), ignoringParenImpCasts( cxxMemberCallExpr( callee( cxxMethodDecl( hasName(\"instance\"), ofClass( hasName(\"QPluginLoader\") ) ) ) ) ) ) ) ) ), cxxMemberCallExpr( callee( cxxMethodDecl( hasName(\"deleteLater\") ) ), on( expr( anyOf( ignoringParenImpCasts( declRefExpr( to( varDecl( hasInitializer( expr( anyOf( ignoringParenImpCasts( cxxMemberCallExpr( callee( cxxMethodDecl( hasName(\"instance\"), ofClass( hasName(\"QPluginLoader\") ) ) ) ) ), ignoringParenImpCasts( castExpr( hasSourceExpression( ignoringParenImpCasts( cxxMemberCallExpr( callee( cxxMethodDecl( hasName(\"instance\"), ofClass( hasName(\"QPluginLoader\") ) ) ) ) ) ) ) ), ignoringParenImpCasts( callExpr( callee( functionDecl( hasName(\"qobject_cast\") ) ), hasArgument( 0, ignoringParenImpCasts( cxxMemberCallExpr( callee( cxxMethodDecl( hasName(\"instance\"), ofClass( hasName(\"QPluginLoader\") ) ) ) ) ) ) ) ) ) ) ) ) ) ) ), ignoringParenImpCasts( cxxMemberCallExpr( callee( cxxMethodDecl( hasName(\"instance\"), ofClass( hasName(\"QPluginLoader\") ) ) ) ) ) ) ) ) ) ) ).bind(\"root\")",
+  "Diagnostic": [
+    {
+      "BindName": "root",
+      "Message": "This object is the root component returned by QPluginLoader::instance() and is owned by the plugin loader. Do not delete it manually; QPluginLoader::unload() deletes the root component when the plugin is actually unloaded.",
+      "Level": "Warning"
+    }
+  ]
+}

--- a/tests/include/QtCore/QObject
+++ b/tests/include/QtCore/QObject
@@ -1,0 +1,9 @@
+#pragma once
+class QObject {
+public:
+    virtual ~QObject() = default;
+    void deleteLater();
+};
+
+template<typename T>
+T qobject_cast(QObject *object);

--- a/tests/include/QtCore/QPluginLoader
+++ b/tests/include/QtCore/QPluginLoader
@@ -1,0 +1,11 @@
+#pragma once
+#include "QObject"
+
+class QPluginLoader {
+public:
+    QPluginLoader(const char *fileName);
+    ~QPluginLoader();
+
+    QObject *instance();
+    bool unload();
+};

--- a/tests/qt-kde-lint-qpluginloader-instance-delete/bad-2.cpp
+++ b/tests/qt-kde-lint-qpluginloader-instance-delete/bad-2.cpp
@@ -1,0 +1,8 @@
+#include <QtCore/QPluginLoader>
+#include <QtCore/QObject>
+
+void foo() {
+    QPluginLoader loader("plugin.so");
+    QObject *plugin = loader.instance();
+    plugin->deleteLater();
+}

--- a/tests/qt-kde-lint-qpluginloader-instance-delete/bad-3.cpp
+++ b/tests/qt-kde-lint-qpluginloader-instance-delete/bad-3.cpp
@@ -1,0 +1,10 @@
+#include <QtCore/QPluginLoader>
+#include <QtCore/QObject>
+
+class Interface : public QObject {};
+
+void foo() {
+    QPluginLoader loader("plugin.so");
+    Interface *plugin = qobject_cast<Interface *>(loader.instance());
+    delete plugin;
+}

--- a/tests/qt-kde-lint-qpluginloader-instance-delete/bad-4.cpp
+++ b/tests/qt-kde-lint-qpluginloader-instance-delete/bad-4.cpp
@@ -1,0 +1,10 @@
+#include <QtCore/QPluginLoader>
+#include <QtCore/QObject>
+
+class Interface : public QObject {};
+
+void foo() {
+    QPluginLoader loader("plugin.so");
+    Interface *plugin = static_cast<Interface *>(loader.instance());
+    delete plugin;
+}

--- a/tests/qt-kde-lint-qpluginloader-instance-delete/bad-5.cpp
+++ b/tests/qt-kde-lint-qpluginloader-instance-delete/bad-5.cpp
@@ -1,0 +1,10 @@
+#include <QtCore/QPluginLoader>
+#include <QtCore/QObject>
+
+class Interface : public QObject {};
+
+void foo() {
+    QPluginLoader loader("plugin.so");
+    Interface *plugin = dynamic_cast<Interface *>(loader.instance());
+    delete plugin;
+}

--- a/tests/qt-kde-lint-qpluginloader-instance-delete/bad-6.cpp
+++ b/tests/qt-kde-lint-qpluginloader-instance-delete/bad-6.cpp
@@ -1,0 +1,10 @@
+#include <QtCore/QPluginLoader>
+#include <QtCore/QObject>
+
+class Interface : public QObject {};
+
+void foo() {
+    QPluginLoader loader("plugin.so");
+    Interface *plugin = dynamic_cast<Interface *>(loader.instance());
+    plugin->deleteLater();
+}

--- a/tests/qt-kde-lint-qpluginloader-instance-delete/bad-7.cpp
+++ b/tests/qt-kde-lint-qpluginloader-instance-delete/bad-7.cpp
@@ -1,0 +1,10 @@
+#include <QtCore/QPluginLoader>
+#include <QtCore/QObject>
+
+class Interface : public QObject {};
+
+void foo() {
+    QPluginLoader loader("plugin.so");
+    Interface *plugin = qobject_cast<Interface *>(loader.instance());
+    plugin->deleteLater();
+}

--- a/tests/qt-kde-lint-qpluginloader-instance-delete/bad.cpp
+++ b/tests/qt-kde-lint-qpluginloader-instance-delete/bad.cpp
@@ -1,0 +1,9 @@
+#include <QtCore/QPluginLoader>
+#include <QtCore/QObject>
+
+void foo() {
+    QPluginLoader loader("plugin.so");
+    QObject *plugin = loader.instance();
+    loader.unload();
+    delete plugin;
+}

--- a/tests/qt-kde-lint-qpluginloader-instance-delete/good-2.cpp
+++ b/tests/qt-kde-lint-qpluginloader-instance-delete/good-2.cpp
@@ -1,0 +1,10 @@
+#include <QtCore/QPluginLoader>
+#include <QtCore/QObject>
+
+class Interface : public QObject {};
+
+void foo() {
+    QPluginLoader loader("plugin.so");
+    Interface *plugin = qobject_cast<Interface *>(loader.instance());
+    loader.unload();
+}

--- a/tests/qt-kde-lint-qpluginloader-instance-delete/good-3.cpp
+++ b/tests/qt-kde-lint-qpluginloader-instance-delete/good-3.cpp
@@ -1,0 +1,13 @@
+#include <QtCore/QPluginLoader>
+#include <QtCore/QObject>
+
+class Wrapper {
+public:
+    Wrapper(QObject *obj) {}
+};
+
+void foo() {
+    QPluginLoader loader("plugin.so");
+    auto *wrapper = new Wrapper(loader.instance());
+    delete wrapper;
+}

--- a/tests/qt-kde-lint-qpluginloader-instance-delete/good.cpp
+++ b/tests/qt-kde-lint-qpluginloader-instance-delete/good.cpp
@@ -1,0 +1,8 @@
+#include <QtCore/QPluginLoader>
+#include <QtCore/QObject>
+
+void foo() {
+    QPluginLoader loader("plugin.so");
+    QObject *plugin = loader.instance();
+    loader.unload();
+}


### PR DESCRIPTION
Adds the `qt-kde-lint-qpluginloader-instance-delete` rule to prevent memory issues from manually deleting the `QPluginLoader` root component.

Addresses #23.

---
*PR created automatically by Jules for task [2943222933534862911](https://jules.google.com/task/2943222933534862911) started by @arran4*