### PR TITLE
Rule: detect unescaped dynamic data in QLabel and QMessageBox

### DIFF
--- a/rules/qt-kde-lint-qlabel-qmessagebox-unescaped-rich-text.json
+++ b/rules/qt-kde-lint-qlabel-qmessagebox-unescaped-rich-text.json
@@ -1,0 +1,16 @@
+{
+  "Name": "qt-kde-lint-qlabel-qmessagebox-unescaped-rich-text",
+  "Query": "match expr(anyOf(callExpr(callee(functionDecl(anyOf(hasName(\"about\"),hasName(\"critical\"),hasName(\"information\"),hasName(\"question\"),hasName(\"warning\")),hasDeclContext(cxxRecordDecl(hasName(\"QMessageBox\"))))),hasAnyArgument(expr(hasType(cxxRecordDecl(hasName(\"QString\"))),unless(anyOf(hasDescendant(stringLiteral()),hasDescendant(cxxMemberCallExpr(callee(cxxMethodDecl(hasName(\"toHtmlEscaped\")))))))).bind(\"messagebox_dynamic_arg\"))).bind(\"messagebox_call\"),cxxMemberCallExpr(callee(cxxMethodDecl(hasName(\"setText\"), ofClass(hasName(\"QLabel\")))),hasArgument(0,expr(hasType(cxxRecordDecl(hasName(\"QString\"))),anyOf(ignoringImplicit(cxxMemberCallExpr(callee(cxxMethodDecl(hasName(\"arg\"))),unless(hasDescendant(cxxMemberCallExpr(callee(cxxMethodDecl(hasName(\"toHtmlEscaped\")))))))),unless(anyOf(stringLiteral(),hasDescendant(stringLiteral()),hasDescendant(cxxMemberCallExpr(callee(cxxMethodDecl(hasName(\"toHtmlEscaped\"))))))))).bind(\"qlabel_dynamic_arg\")),anyOf(on(expr(unless(declRefExpr()))),allOf(on(declRefExpr(to(varDecl().bind(\"qlabel_var\")))),unless(hasAncestor(compoundStmt(hasDescendant(cxxMemberCallExpr(callee(cxxMethodDecl(hasName(\"setTextFormat\"), ofClass(hasName(\"QLabel\")))),on(declRefExpr(to(varDecl(equalsBoundNode(\"qlabel_var\"))))))))))))).bind(\"qlabel_call\")))",
+  "Diagnostic": [
+    {
+      "BindName": "qlabel_call",
+      "Message": "Dynamic text is formatted into an HTML string literal without escaping. Call .toHtmlEscaped() on dynamic values inserted into HTML to avoid injection.",
+      "Level": "Warning"
+    },
+    {
+      "BindName": "messagebox_call",
+      "Message": "QMessageBox displays strings as rich text by default if they resemble HTML. Escape external data with .toHtmlEscaped() before passing it to static QMessageBox functions.",
+      "Level": "Warning"
+    }
+  ]
+}

--- a/tests/qt-kde-lint-qlabel-qmessagebox-unescaped-rich-text/bad.cpp
+++ b/tests/qt-kde-lint-qlabel-qmessagebox-unescaped-rich-text/bad.cpp
@@ -1,0 +1,29 @@
+struct QString {
+    QString arg(const QString&) const;
+    QString toHtmlEscaped() const;
+    QString() {}
+    QString(const char*) {}
+};
+#define QStringLiteral(str) QString(str)
+
+struct QLabel {
+    void setText(const QString&);
+};
+struct QWidget {};
+struct QMessageBox {
+    static void warning(QWidget*, const QString&, const QString&);
+};
+
+void f() {
+    QLabel* label = new QLabel;
+    QString dynamicVal;
+
+    // Pattern 2: HTML string literals built with .arg(dynamicExpr)
+    label->setText(QStringLiteral("<b>%1</b>").arg(dynamicVal));
+
+    // Direct passing
+    label->setText(dynamicVal);
+
+    QWidget* w = nullptr;
+    QMessageBox::warning(w, "Title", dynamicVal);
+}

--- a/tests/qt-kde-lint-qlabel-qmessagebox-unescaped-rich-text/good.cpp
+++ b/tests/qt-kde-lint-qlabel-qmessagebox-unescaped-rich-text/good.cpp
@@ -1,0 +1,29 @@
+struct QString {
+    QString arg(const QString&) const;
+    QString toHtmlEscaped() const;
+    QString() {}
+    QString(const char*) {}
+};
+#define QStringLiteral(str) QString(str)
+
+struct QLabel {
+    void setText(const QString&);
+};
+struct QWidget {};
+struct QMessageBox {
+    static void warning(QWidget*, const QString&, const QString&);
+    static void information(QWidget*, const QString&, const QString&);
+};
+
+void f() {
+    QLabel* label = new QLabel;
+    QString dynamicVal;
+
+    // Pattern 2: HTML string literals built with .arg(dynamicExpr)
+    label->setText(QStringLiteral("<b>%1</b>").arg(dynamicVal.toHtmlEscaped()));
+
+    QWidget* w = nullptr;
+    QMessageBox::information(w, "Title", "Static");
+    QMessageBox::warning(w, "Title", dynamicVal.toHtmlEscaped());
+    QMessageBox::warning(w, "Title", QString("Static"));
+}


### PR DESCRIPTION
Add a new static analysis lint rule via Clang AST Matcher to detect dynamic strings passed to `QLabel::setText` and static `QMessageBox` convenience functions that are missing `.toHtmlEscaped()` to prevent rich-text injection, per issue #14. Positive and negative test fixtures were also included.

---
*PR created automatically by Jules for task [18215258885666530708](https://jules.google.com/task/18215258885666530708) started by @arran4*