### PR TITLE
Implement QML action semantic context linting

### DIFF
--- a/docs/rules/qt-kde-lint-action-semantic-context.md
+++ b/docs/rules/qt-kde-lint-action-semantic-context.md
@@ -1,0 +1,18 @@
+# qt-kde-lint-action-semantic-context
+
+Warns when the text label of an Action lacks a semantic context. Translators benefit from semantic hints, particularly when the text might have different meanings depending on where it appears in the UI (e.g., in a menu vs on a button).
+
+By providing an `@action` context in the `i18nc()` or `i18ndc()` call, translators can provide more accurate localizations.
+
+## QML Rule Boundary
+The QML implementation of this rule specifically targets `Action` and `Kirigami.Action` objects in `.qml` files.
+
+Because we prefer precision over recall, the rule deliberately does *not* trigger on generic identifiers ending in `.Action` (like `MyControls.Action`) unless they are resolved to known KDE/Qt actions. This keeps false positives low.
+
+The rule correctly recommends `i18nc` instead of `i18n`, and `i18ndc` instead of `i18nd`. It ignores translations that already have a context.
+
+## Relation to C++ Rule
+This QML rule directly parallels the C++ `qt-kde-lint-action-semantic-context` rule, which flags the usage of `i18n()` (without context) inside `QAction` constructors and related QAction setter/adder methods like `QAction::setText` or `QMenu::addAction`. Both use the same diagnostic ID for consistent reporting across both C++ and QML runtimes.
+
+## Existing Tooling Assessment
+Prior to adding this rule to `qml_linter.py`, an assessment was made on whether `qmllint` or standard `KI18n` toolings support this semantic action diagnostic natively. Existing KDE static analysis and localization extractors (`xgettext` based) primarily focus on extracting strings and diagnosing syntax errors, but do not statically enforce the usage of context arguments specifically bounded by `Action` types in QML or C++. Thus, this rule adds valuable coverage that doesn't duplicate existing `qmllint` coverage.

--- a/tests/qml/qt-kde-lint-action-semantic-context/bad.qml
+++ b/tests/qml/qt-kde-lint-action-semantic-context/bad.qml
@@ -1,0 +1,20 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+Item {
+    Action {
+        // [custom-qt-kde-lint-action-semantic-context]
+        text: i18n("Copy Link Address")
+    }
+
+    Action {
+        id: customAction
+        // [custom-qt-kde-lint-action-semantic-context]
+        text: i18nd("mydomain", "Copy Link Address")
+    }
+
+    Kirigami.Action {
+        // [custom-qt-kde-lint-action-semantic-context]
+        text: i18n("Do Something")
+    }
+}

--- a/tests/qml/qt-kde-lint-action-semantic-context/good.qml
+++ b/tests/qml/qt-kde-lint-action-semantic-context/good.qml
@@ -1,0 +1,37 @@
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+Item {
+    Action {
+        text: i18nc("@action", "Copy Link Address")
+    }
+
+    Kirigami.Action {
+        text: i18ndc("mydomain", "@action", "Do Something")
+    }
+
+    // Ordinary text properties should not trigger
+    Text {
+        text: i18n("Normal text")
+    }
+
+    Label {
+        text: i18n("Normal label")
+    }
+
+    // Other properties should not trigger
+    Action {
+        description: i18n("Action description")
+        tooltip: i18n("Tooltip")
+    }
+
+    // String literals lookalikes or other forms shouldn't crash it
+    Action {
+        text: "i18n('Copy Link Address')"
+    }
+
+    // Custom objects should not trigger
+    MyObject {
+        text: i18n("Custom object text")
+    }
+}

--- a/tests/qml/qt-kde-lint-action-semantic-context/good.qml
+++ b/tests/qml/qt-kde-lint-action-semantic-context/good.qml
@@ -34,4 +34,12 @@ Item {
     MyObject {
         text: i18n("Custom object text")
     }
+
+    MyControls.Action {
+        text: i18n("Custom action-like component")
+    }
+
+    Something.Action {
+        text: i18nd("mydomain", "Custom action")
+    }
 }

--- a/tools/qml_linter.py
+++ b/tools/qml_linter.py
@@ -723,20 +723,22 @@ def qt_kde_lint_qml_transient_object_leak(context):
 def qt_kde_lint_action_semantic_context(context):
     def visit(node):
         if node.type == 'ui_object_definition':
-            # Check if this object is an Action or Kirigami.Action
+            # Check if this object is an Action or Kirigami.Action strictly
             is_action = False
             for child in node.children:
                 if child.type == 'identifier' and child.text == b'Action':
                     is_action = True
                     break
                 elif child.type == 'nested_identifier':
-                    # e.g. Kirigami.Action
-                    # The last child should be an identifier 'Action'
-                    last_ident = None
-                    for subchild in child.children:
-                        if subchild.type == 'identifier':
-                            last_ident = subchild
-                    if last_ident and last_ident.text == b'Action':
+                    # Check strictly for Kirigami.Action
+                    parts = []
+                    def get_parts(n):
+                        if n.type == 'identifier':
+                            parts.append(n.text)
+                        for c in n.children:
+                            get_parts(c)
+                    get_parts(child)
+                    if parts == [b'Kirigami', b'Action']:
                         is_action = True
                         break
 
@@ -751,11 +753,20 @@ def qt_kde_lint_action_semantic_context(context):
                                 if exp_child.type == 'call_expression':
                                     ident = exp_child.children[0]
                                     if ident.type == 'identifier' and ident.text in (b'i18n', b'i18nd', b'ki18n', b'ki18nd'):
+                                        # Determine the suggested function
+                                        call_name = ident.text.decode('utf-8')
+                                        sugg = call_name.replace('i18n', 'i18nc')
+                                        if call_name == 'i18nd': sugg = 'i18ndc'
+                                        if call_name == 'ki18nd': sugg = 'ki18ndc'
+                                        if call_name == 'ki18n': sugg = 'ki18nc'
+                                        # Actually it's simple: just append 'c' to the call name
+                                        sugg = call_name + 'c'
+
                                         # It's missing context
                                         context.report_issue(
-                                            exp_child, # or val_node, or node? let's use the binding or the exp_child
+                                            exp_child,
                                             "qt-kde-lint-action-semantic-context",
-                                            'UI action labels translated with plain i18n() lack semantic context. Prefer i18nc() with a semantic context such as "@action" to aid translators.'
+                                            f'UI action labels translated with plain {call_name}() lack semantic context. Prefer {sugg}() with a semantic context such as "@action" to aid translators.'
                                         )
 
     context.walk(context.tree.root_node, visit)

--- a/tools/qml_linter.py
+++ b/tools/qml_linter.py
@@ -718,6 +718,48 @@ def qt_kde_lint_qml_transient_object_leak(context):
 
     context.walk(context.tree.root_node, visit)
 
+
+@register_rule
+def qt_kde_lint_action_semantic_context(context):
+    def visit(node):
+        if node.type == 'ui_object_definition':
+            # Check if this object is an Action or Kirigami.Action
+            is_action = False
+            for child in node.children:
+                if child.type == 'identifier' and child.text == b'Action':
+                    is_action = True
+                    break
+                elif child.type == 'nested_identifier':
+                    # e.g. Kirigami.Action
+                    # The last child should be an identifier 'Action'
+                    last_ident = None
+                    for subchild in child.children:
+                        if subchild.type == 'identifier':
+                            last_ident = subchild
+                    if last_ident and last_ident.text == b'Action':
+                        is_action = True
+                        break
+
+            if is_action:
+                # Find its text property
+                for child in node.children:
+                    if child.type == 'ui_object_initializer':
+                        val_node = context.get_property_binding(child, b'text')
+                        if val_node:
+                            # val_node is an expression_statement
+                            for exp_child in val_node.children:
+                                if exp_child.type == 'call_expression':
+                                    ident = exp_child.children[0]
+                                    if ident.type == 'identifier' and ident.text in (b'i18n', b'i18nd', b'ki18n', b'ki18nd'):
+                                        # It's missing context
+                                        context.report_issue(
+                                            exp_child, # or val_node, or node? let's use the binding or the exp_child
+                                            "qt-kde-lint-action-semantic-context",
+                                            'UI action labels translated with plain i18n() lack semantic context. Prefer i18nc() with a semantic context such as "@action" to aid translators.'
+                                        )
+
+    context.walk(context.tree.root_node, visit)
+
 def check_qml(filepath):
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")


### PR DESCRIPTION
## Summary

Adds the QML side of `qt-kde-lint-action-semantic-context` using the existing tree-sitter QML AST path.

- Warns for plain no-context translation calls used directly as `text:` on known `Action` / `Kirigami.Action` objects.
- Preserves precision over recall: arbitrary qualified custom types such as `MyControls.Action` and `Something.Action` are deliberately ignored.
- Keeps context-aware `i18nc()` / `i18ndc()` forms safe and gives domain-preserving recommendations for `i18nd()` / `ki18nd()`.
- Adds positive and adversarial negative QML fixtures.
- Documents the QML rule boundary and its relationship to the existing C++ diagnostic in `docs/rules/qt-kde-lint-action-semantic-context.md`.

## Policy / existing-tool check

KDE's localization semantics use `@action` (and more specific subcues such as `@action:button`) for action text; the Kirigami documentation likewise demonstrates `Kirigami.Action` labels with `i18nc("@action:button", ...)`:

- https://techbase.kde.org/Special:MyLanguage/Development/Tutorials/Localization/i18n_Semantics
- https://develop.kde.org/docs/getting-started/kirigami/introduction-actions/

Qt's current `qmllint` warning set covers QML syntax/type/anti-pattern diagnostics but does not provide an equivalent semantic KI18n action-context check, so this rule supplies distinct coverage:

- https://doc.qt.io/qt-6/qtqml-tooling-qmllint.html

## Verification

- Full repository CI is green on the current head (`996297517fef81b93bc16b62cd17ce4b05a799bc`).
- Adversarial fixtures verify that custom qualified `*.Action` components do not trigger.

Fixes #53

---
*PR created automatically by Jules for task [13870680555842531021](https://jules.google.com/task/13870680555842531021) started by @arran4*