### PR TITLE
feat: implement root composite action and runner

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -1,0 +1,92 @@
+name: test-action
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test-action:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install LLVM 23 clang-tidy
+        run: |
+          wget -q https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 23
+          sudo apt-get install -y clang-tidy-23
+          clang-tidy-23 --version
+
+      - name: Setup test fixtures
+        run: |
+          mkdir -p build
+          echo '[{"directory": "'$(pwd)/build'", "command": "clang++ -c -std=c++17 ../tests/qt-kde-lint-connect-by-name/good.cpp", "file": "../tests/qt-kde-lint-connect-by-name/good.cpp"}]' > build/compile_commands.json
+
+      - name: Test action success (both)
+        uses: ./
+        with:
+          build-directory: build
+          cpp-paths: tests/qt-kde-lint-connect-by-name/good.cpp
+          qml-paths: tests/qml/qt-kde-lint-qml-transient-object-leak/good.qml
+
+      - name: Test action failure (both)
+        id: test-failure
+        continue-on-error: true
+        uses: ./
+        with:
+          build-directory: build
+          cpp-paths: tests/qt-kde-lint-connect-by-name/bad.cpp
+          qml-paths: tests/qml/qt-kde-lint-qml-transient-object-leak/bad.qml
+
+      - name: Check failure (both)
+        run: |
+          if [ "${{ steps.test-failure.outcome }}" == "success" ]; then
+            echo "Action should have failed but succeeded"
+            false
+          fi
+
+      - name: Test action success (C++ only)
+        uses: ./
+        with:
+          build-directory: build
+          cpp-paths: tests/qt-kde-lint-connect-by-name/good.cpp
+
+      - name: Test action failure (C++ only)
+        id: test-cpp-failure
+        continue-on-error: true
+        uses: ./
+        with:
+          build-directory: build
+          cpp-paths: tests/qt-kde-lint-connect-by-name/bad.cpp
+
+      - name: Check failure (C++ only)
+        run: |
+          if [ "${{ steps.test-cpp-failure.outcome }}" == "success" ]; then
+            echo "Action should have failed but succeeded"
+            false
+          fi
+
+      - name: Test action success (QML only)
+        uses: ./
+        with:
+          qml-paths: tests/qml/qt-kde-lint-qml-transient-object-leak/good.qml
+
+      - name: Test action failure (QML only)
+        id: test-qml-failure
+        continue-on-error: true
+        uses: ./
+        with:
+          qml-paths: tests/qml/qt-kde-lint-qml-transient-object-leak/bad.qml
+
+      - name: Check failure (QML only)
+        run: |
+          if [ "${{ steps.test-qml-failure.outcome }}" == "success" ]; then
+            echo "Action should have failed but succeeded"
+            false
+          fi

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup test fixtures
         run: |
           mkdir -p build
-          echo '[{"directory": "'$(pwd)/build'", "command": "clang++ -c -std=c++17 ../tests/qt-kde-lint-contextless-qobject-capture/good.cpp", "file": "../tests/qt-kde-lint-contextless-qobject-capture/good.cpp"}]' > build/compile_commands.json
+          echo '[{"directory": "'$(pwd)/build'", "command": "clang++ -c -std=c++17 ../tests/qt-kde-lint-contextless-qobject-capture/good.cpp", "file": "../tests/qt-kde-lint-contextless-qobject-capture/good.cpp"}, {"directory": "'$(pwd)/build'", "command": "clang++ -c -std=c++17 ../tests/qt-kde-lint-contextless-qobject-capture/bad.cpp", "file": "../tests/qt-kde-lint-contextless-qobject-capture/bad.cpp"}]' > build/compile_commands.json
 
       - name: Test action success (both)
         uses: ./

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           build-directory: build
           cpp-paths: tests/qt-kde-lint-contextless-qobject-capture/good.cpp
-          qml-paths: tests/qml/qt-kde-lint-qml-transient-object-leak/good.qml
+          qml-paths: tests/qml/qt-kde-lint-qml-transient-object-leak/good_explicit_destroy.qml
 
       - name: Test action failure (both)
         id: test-failure
@@ -42,7 +42,7 @@ jobs:
         with:
           build-directory: build
           cpp-paths: tests/qt-kde-lint-contextless-qobject-capture/bad.cpp
-          qml-paths: tests/qml/qt-kde-lint-qml-transient-object-leak/bad.qml
+          qml-paths: tests/qml/qt-kde-lint-qml-transient-object-leak/bad_repeatable_handler.qml
 
       - name: Check failure (both)
         run: |
@@ -75,14 +75,14 @@ jobs:
       - name: Test action success (QML only)
         uses: ./
         with:
-          qml-paths: tests/qml/qt-kde-lint-qml-transient-object-leak/good.qml
+          qml-paths: tests/qml/qt-kde-lint-qml-transient-object-leak/good_explicit_destroy.qml
 
       - name: Test action failure (QML only)
         id: test-qml-failure
         continue-on-error: true
         uses: ./
         with:
-          qml-paths: tests/qml/qt-kde-lint-qml-transient-object-leak/bad.qml
+          qml-paths: tests/qml/qt-kde-lint-qml-transient-object-leak/bad_repeatable_handler.qml
 
       - name: Check failure (QML only)
         run: |

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -26,13 +26,13 @@ jobs:
       - name: Setup test fixtures
         run: |
           mkdir -p build
-          echo '[{"directory": "'$(pwd)/build'", "command": "clang++ -c -std=c++17 ../tests/qt-kde-lint-connect-by-name/good.cpp", "file": "../tests/qt-kde-lint-connect-by-name/good.cpp"}]' > build/compile_commands.json
+          echo '[{"directory": "'$(pwd)/build'", "command": "clang++ -c -std=c++17 ../tests/qt-kde-lint-contextless-qobject-capture/good.cpp", "file": "../tests/qt-kde-lint-contextless-qobject-capture/good.cpp"}]' > build/compile_commands.json
 
       - name: Test action success (both)
         uses: ./
         with:
           build-directory: build
-          cpp-paths: tests/qt-kde-lint-connect-by-name/good.cpp
+          cpp-paths: tests/qt-kde-lint-contextless-qobject-capture/good.cpp
           qml-paths: tests/qml/qt-kde-lint-qml-transient-object-leak/good.qml
 
       - name: Test action failure (both)
@@ -41,7 +41,7 @@ jobs:
         uses: ./
         with:
           build-directory: build
-          cpp-paths: tests/qt-kde-lint-connect-by-name/bad.cpp
+          cpp-paths: tests/qt-kde-lint-contextless-qobject-capture/bad.cpp
           qml-paths: tests/qml/qt-kde-lint-qml-transient-object-leak/bad.qml
 
       - name: Check failure (both)
@@ -55,7 +55,7 @@ jobs:
         uses: ./
         with:
           build-directory: build
-          cpp-paths: tests/qt-kde-lint-connect-by-name/good.cpp
+          cpp-paths: tests/qt-kde-lint-contextless-qobject-capture/good.cpp
 
       - name: Test action failure (C++ only)
         id: test-cpp-failure
@@ -63,7 +63,7 @@ jobs:
         uses: ./
         with:
           build-directory: build
-          cpp-paths: tests/qt-kde-lint-connect-by-name/bad.cpp
+          cpp-paths: tests/qt-kde-lint-contextless-qobject-capture/bad.cpp
 
       - name: Check failure (C++ only)
         run: |

--- a/README.md
+++ b/README.md
@@ -64,52 +64,28 @@ Query-based custom checks currently require `--experimental-custom-checks`. The 
 
 ## GitHub Actions integration
 
-`qt-kde-lint` is intended to run as an additional static-analysis pass in the same CI pipeline that already builds Qt/KDE code. It should **not** replace the project's normal compiler warnings, `.clang-tidy`, Clazy, `cppcheck`, formatting, build, or tests.
+The easiest way to run `qt-kde-lint` in GitHub Actions is to use the provided composite action. It can run both C++ and QML checks as an additional static-analysis pass. It should **not** replace the project's normal compiler warnings, `.clang-tidy`, Clazy, `cppcheck`, formatting, build, or tests.
 
-The instructions below are intended to work with common Qt/KDE GitHub Actions layouts, including:
-
-- a dedicated C++/Qt lint job that already creates `compile_commands.json` and runs clang-tidy;
-- a combined build/test job where static analysis is currently limited to formatting or `cppcheck`;
-- container-based jobs using a KDE/openSUSE, Debian, Ubuntu, or similar build environment.
-
-A consumer workflow needs three things:
-
+A consumer workflow needs three things for C++ checks:
 1. a CMake compilation database generated with `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON`;
 2. clang-tidy 23 or newer, because query-based custom checks are currently experimental;
-3. a checkout of this repository so `tools/build_config.py` can generate the custom-check configuration.
-
-The generated configuration intentionally enables only `custom-qt-kde-lint-*`. Run it as a **second clang-tidy pass** rather than supplying it to the project's normal clang-tidy invocation, otherwise the generated `Checks: -*,custom-qt-kde-lint-*` setting would replace the project's normal check selection.
+3. using the `qt-kde-lint` action as a step.
 
 ### Minimal addition to an existing Qt/C++ lint job
 
 If a lint job already configures the project with `CMAKE_EXPORT_COMPILE_COMMANDS=ON`, add the following after configuration and after any existing clang-tidy/Clazy checks:
 
 ```yaml
-      - name: Check out qt-kde-lint
-        uses: actions/checkout@v4
-        with:
-          repository: arran4/qt-kde-lint
-          # Pin a release tag or commit for reproducible CI once releases exist.
-          ref: main
-          path: .qt-kde-lint
-
-      - name: Generate qt-kde-lint configuration
-        run: |
-          python3 .qt-kde-lint/tools/build_config.py \
-            --rules-dir .qt-kde-lint/rules \
-            --output build/qt-kde-lint.clang-tidy
-
       - name: Run qt-kde-lint
-        run: |
-          clang-tidy-23 --version
-          find src tests bench -type f \
-            \( -name '*.cpp' -o -name '*.cc' -o -name '*.cxx' \) \
-            -print0 2>/dev/null \
-            | xargs -0 -r clang-tidy-23 \
-                --experimental-custom-checks \
-                --config-file=build/qt-kde-lint.clang-tidy \
-                -p build
+        uses: arran4/qt-kde-lint@v1
+        with:
+          build-directory: build
+          cpp-paths: src tests bench
+          qml-paths: src
+          clang-tidy: clang-tidy-23
 ```
+
+The action will handle generating the configuration and invoking `clang-tidy` as a second pass.
 
 Adjust the source directories for the project. Running translation units from the compilation database is sufficient to analyze code in included headers as well; there is normally no need to invoke clang-tidy separately on every header.
 
@@ -138,25 +114,12 @@ A workflow that already runs clang-tidy should normally look conceptually like t
       - name: Existing clang-tidy and Clazy checks
         run: run-clang-tidy -p build src tests
 
-      - name: Check out qt-kde-lint
-        uses: actions/checkout@v4
+      - name: Run qt-kde-lint
+        uses: arran4/qt-kde-lint@v1
         with:
-          repository: arran4/qt-kde-lint
-          ref: main
-          path: .qt-kde-lint
-
-      - name: qt-kde-lint
-        run: |
-          python3 .qt-kde-lint/tools/build_config.py \
-            --rules-dir .qt-kde-lint/rules \
-            --output build/qt-kde-lint.clang-tidy
-          find src tests -type f \
-            \( -name '*.cpp' -o -name '*.cc' -o -name '*.cxx' \) \
-            -print0 2>/dev/null \
-            | xargs -0 -r clang-tidy-23 \
-                --experimental-custom-checks \
-                --config-file=build/qt-kde-lint.clang-tidy \
-                -p build
+          build-directory: build
+          cpp-paths: src tests
+          clang-tidy: clang-tidy-23
 ```
 
 The important point is that the project's normal `.clang-tidy` remains authoritative for its existing checks, while qt-kde-lint supplies a separate generated configuration containing only this project's custom checks.
@@ -187,31 +150,17 @@ For example:
 
       - uses: actions/checkout@v4
 
-      - name: Check out qt-kde-lint
-        uses: actions/checkout@v4
-        with:
-          repository: arran4/qt-kde-lint
-          ref: main
-          path: .qt-kde-lint
-
       - name: Configure CMake for analysis
         run: cmake -S . -B build -G Ninja \
           -DCMAKE_BUILD_TYPE=Release \
           -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 
       - name: Run qt-kde-lint
-        run: |
-          clang-tidy-23 --version
-          python3 .qt-kde-lint/tools/build_config.py \
-            --rules-dir .qt-kde-lint/rules \
-            --output build/qt-kde-lint.clang-tidy
-          find src tests -type f \
-            \( -name '*.cpp' -o -name '*.cc' -o -name '*.cxx' \) \
-            -print0 2>/dev/null \
-            | xargs -0 -r clang-tidy-23 \
-                --experimental-custom-checks \
-                --config-file=build/qt-kde-lint.clang-tidy \
-                -p build
+        uses: arran4/qt-kde-lint@v1
+        with:
+          build-directory: build
+          cpp-paths: src tests
+          clang-tidy: clang-tidy-23
 ```
 
 Keep the normal build/test job on its preferred distribution if desired. The analysis job only needs to configure the project successfully and expose the same headers, generated files, include paths, compile definitions, and language options closely enough for clang-tidy to parse the real build.
@@ -241,6 +190,30 @@ On an image where `clang-tidy-23` is available directly, install the versioned p
 
 If the normal Qt/KDE build image does not provide clang-tidy 23 yet, keep the existing lint/build job unchanged and add a dedicated qt-kde-lint job using an LLVM-23-capable image with the same project development dependencies. Do not silently fall back to clang-tidy 22 or older: those versions do not provide the custom-check interface this repository currently targets.
 
+### Canonical Runner (Local/Non-GitHub usage)
+
+For local development or non-GitHub CI (like GitLab, KDE CI, Gentoo), the repository provides a canonical runner `tools/run.py` which unifies C++ and QML linting.
+
+```sh
+git clone https://github.com/arran4/qt-kde-lint.git .qt-kde-lint
+
+# Install QML dependencies if running QML checks
+pip install -r .qt-kde-lint/requirements-qml.txt
+
+# Run the unified runner
+python3 .qt-kde-lint/tools/run.py \
+    --build-dir build \
+    --clang-tidy clang-tidy-23 \
+    --cpp-paths src tests bench \
+    --qml-paths src
+```
+
+The runner accepts:
+- `--build-dir`: Build directory containing `compile_commands.json`
+- `--clang-tidy`: The clang-tidy executable to use
+- `--cpp-paths`: Paths to scan for C++ files
+- `--qml-paths`: Paths to scan for QML files
+
 ### CI enforcement
 
 For automated testing, qt-kde-lint must run in a job that actually executes for pull requests and pushes where code checks are expected.
@@ -265,11 +238,9 @@ Either makes the integration informational rather than protective. The intended 
 
 Existing legacy/static-analysis steps may temporarily soft-fail while their warning backlog is being migrated, but qt-kde-lint rules are intended to be low-noise enough to be merge-blocking from the point they are adopted.
 
-### Why checkout the rules instead of copying them into each project?
+### Why use the action instead of copying rules?
 
-Keeping the rule definitions in this repository means every consumer runs the same rule IDs, diagnostics, regression-tested matchers, and fixes. Once stable releases/tags exist, consumers should pin the checkout to a tag or commit and update it deliberately, rather than duplicating rule JSON into each Qt/KDE repository.
-
-A reusable/composite GitHub Action may be added later to hide the checkout/config-generation boilerplate. Until that exists, the explicit steps above make the compiler version, compilation database, and rule source visible in each consuming workflow.
+Keeping the rule definitions in this repository means every consumer runs the same rule IDs, diagnostics, regression-tested matchers, and fixes. Once stable releases/tags exist, consumers should pin the action usage (`uses: arran4/qt-kde-lint@v1`) and update it deliberately, rather than duplicating rule JSON into each Qt/KDE repository.
 
 ## Status
 

--- a/action.yml
+++ b/action.yml
@@ -21,28 +21,32 @@ runs:
   steps:
     - name: Ensure Python QML parser dependencies are installed
       if: inputs.qml-paths != ''
-      run: pip install -r ${{ github.action_path }}/requirements-qml.txt
+      run: python3 -m pip install -r ${{ github.action_path }}/requirements-qml.txt
       shell: bash
 
     - name: Run qt-kde-lint
+      env:
+        BUILD_DIR: ${{ inputs.build-directory }}
+        CLANG_TIDY: ${{ inputs.clang-tidy }}
+        CPP_PATHS: ${{ inputs.cpp-paths }}
+        QML_PATHS: ${{ inputs.qml-paths }}
       run: |
         ARGS=()
-        if [ -n "${{ inputs.build-directory }}" ]; then
-          ARGS+=(--build-dir "${{ inputs.build-directory }}")
+        if [ -n "$BUILD_DIR" ]; then
+          ARGS+=(--build-dir "$BUILD_DIR")
         fi
-        if [ -n "${{ inputs.clang-tidy }}" ]; then
-          ARGS+=(--clang-tidy "${{ inputs.clang-tidy }}")
+        if [ -n "$CLANG_TIDY" ]; then
+          ARGS+=(--clang-tidy "$CLANG_TIDY")
         fi
 
-        # Read space-separated paths safely using read -r -a
-        if [ -n "${{ inputs.cpp-paths }}" ]; then
+        if [ -n "$CPP_PATHS" ]; then
           ARGS+=(--cpp-paths)
-          read -r -a CPP_ARRAY <<< "${{ inputs.cpp-paths }}"
+          read -r -a CPP_ARRAY <<< "$CPP_PATHS"
           ARGS+=("${CPP_ARRAY[@]}")
         fi
-        if [ -n "${{ inputs.qml-paths }}" ]; then
+        if [ -n "$QML_PATHS" ]; then
           ARGS+=(--qml-paths)
-          read -r -a QML_ARRAY <<< "${{ inputs.qml-paths }}"
+          read -r -a QML_ARRAY <<< "$QML_PATHS"
           ARGS+=("${QML_ARRAY[@]}")
         fi
 

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,50 @@
+name: 'qt-kde-lint'
+description: 'Run qt-kde-lint checks on C++ and/or QML sources'
+
+inputs:
+  build-directory:
+    description: 'Build directory containing compile_commands.json (required for C++)'
+    required: false
+  cpp-paths:
+    description: 'Space-separated C++ source paths to analyze'
+    required: false
+  qml-paths:
+    description: 'Space-separated QML source paths to analyze'
+    required: false
+  clang-tidy:
+    description: 'clang-tidy executable to use (must be version 23 or newer)'
+    required: false
+    default: 'clang-tidy-23'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Ensure Python QML parser dependencies are installed
+      if: inputs.qml-paths != ''
+      run: pip install -r ${{ github.action_path }}/requirements-qml.txt
+      shell: bash
+
+    - name: Run qt-kde-lint
+      run: |
+        ARGS=()
+        if [ -n "${{ inputs.build-directory }}" ]; then
+          ARGS+=(--build-dir "${{ inputs.build-directory }}")
+        fi
+        if [ -n "${{ inputs.clang-tidy }}" ]; then
+          ARGS+=(--clang-tidy "${{ inputs.clang-tidy }}")
+        fi
+
+        # Read space-separated paths safely using read -r -a
+        if [ -n "${{ inputs.cpp-paths }}" ]; then
+          ARGS+=(--cpp-paths)
+          read -r -a CPP_ARRAY <<< "${{ inputs.cpp-paths }}"
+          ARGS+=("${CPP_ARRAY[@]}")
+        fi
+        if [ -n "${{ inputs.qml-paths }}" ]; then
+          ARGS+=(--qml-paths)
+          read -r -a QML_ARRAY <<< "${{ inputs.qml-paths }}"
+          ARGS+=("${QML_ARRAY[@]}")
+        fi
+
+        python3 ${{ github.action_path }}/tools/run.py "${ARGS[@]}"
+      shell: bash

--- a/tests/harness/test_run.py
+++ b/tests/harness/test_run.py
@@ -1,0 +1,26 @@
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+class TestRunRunner(unittest.TestCase):
+    def setUp(self):
+        self.script_path = Path(__file__).resolve().parent.parent.parent / "tools" / "run.py"
+
+    def test_missing_args(self):
+        result = subprocess.run([sys.executable, str(self.script_path)], capture_output=True, text=True)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("At least one of --cpp-paths or --qml-paths must be provided.", result.stderr)
+
+    def test_missing_build_dir_for_cpp(self):
+        result = subprocess.run([sys.executable, str(self.script_path), "--cpp-paths", "src"], capture_output=True, text=True)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("--build-dir is required when --cpp-paths are provided.", result.stderr)
+
+    def test_missing_compile_commands(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            result = subprocess.run([sys.executable, str(self.script_path), "--cpp-paths", "src", "--build-dir", temp_dir], capture_output=True, text=True)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("compile_commands.json not found", result.stderr)

--- a/tools/run.py
+++ b/tools/run.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Canonical runner for qt-kde-lint consumer integration."""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+def get_clang_tidy_version(executable: str) -> int:
+    try:
+        output = subprocess.run([executable, "--version"], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True).stdout
+        match = re.search(r"LLVM version (\d+)", output)
+        if match:
+            return int(match.group(1))
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        pass
+    return -1
+
+def run_in_chunks(cmd_base: list, files: list, chunk_size=500) -> bool:
+    has_failures = False
+    for i in range(0, len(files), chunk_size):
+        chunk = files[i:i+chunk_size]
+        result = subprocess.run(cmd_base + chunk)
+        if result.returncode != 0:
+            has_failures = True
+    return has_failures
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run qt-kde-lint checks on C++ and/or QML sources.")
+    parser.add_argument("--build-dir", type=Path, help="Build directory containing compile_commands.json")
+    parser.add_argument("--clang-tidy", default="clang-tidy-23", help="clang-tidy executable")
+    parser.add_argument("--cpp-paths", nargs="*", default=[], type=str, help="C++ source paths")
+    parser.add_argument("--qml-paths", nargs="*", default=[], type=str, help="QML source paths")
+
+    args = parser.parse_args()
+
+    if not args.cpp_paths and not args.qml_paths:
+        parser.error("At least one of --cpp-paths or --qml-paths must be provided.")
+
+    script_dir = Path(__file__).resolve().parent
+    repo_root = script_dir.parent
+    has_failures = False
+
+    if args.cpp_paths:
+        if not args.build_dir:
+            parser.error("--build-dir is required when --cpp-paths are provided.")
+
+        compile_commands = args.build_dir / "compile_commands.json"
+        if not compile_commands.exists():
+            print(f"Error: compile_commands.json not found in {args.build_dir}", file=sys.stderr)
+            return 1
+
+        version = get_clang_tidy_version(args.clang_tidy)
+        if version == -1:
+            print(f"Error: clang-tidy executable '{args.clang_tidy}' not found or invalid.", file=sys.stderr)
+            return 1
+        elif version < 23:
+            print(f"Error: qt-kde-lint requires clang-tidy version >= 23, but '{args.clang_tidy}' is version {version}.", file=sys.stderr)
+            return 1
+
+        cpp_files = []
+        for path_str in args.cpp_paths:
+            path = Path(path_str)
+            if path.is_file():
+                cpp_files.append(str(path))
+            elif path.is_dir():
+                for root, _, files in os.walk(path):
+                    for file in files:
+                        if file.endswith((".cpp", ".cc", ".cxx")):
+                            cpp_files.append(os.path.join(root, file))
+
+        if not cpp_files:
+            print("No C++ files found in the provided --cpp-paths.", file=sys.stderr)
+            return 1
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            config_file = Path(temp_dir) / "qt-kde-lint.clang-tidy"
+            build_config_cmd = [
+                sys.executable, str(script_dir / "build_config.py"),
+                "--rules-dir", str(repo_root / "rules"),
+                "--output", str(config_file)
+            ]
+            try:
+                subprocess.run(build_config_cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            except subprocess.CalledProcessError:
+                print("Error: Failed to generate clang-tidy configuration.", file=sys.stderr)
+                return 1
+
+            clang_tidy_cmd = [
+                args.clang_tidy,
+                "--experimental-custom-checks",
+                f"--config-file={config_file}",
+                "-p", str(args.build_dir)
+            ]
+
+            if run_in_chunks(clang_tidy_cmd, cpp_files):
+                has_failures = True
+
+    if args.qml_paths:
+        try:
+            import tree_sitter_qmljs
+        except ImportError:
+            print("Error: Python QML parser dependencies are unavailable. Please install them.", file=sys.stderr)
+            return 1
+
+        qml_files = []
+        for path_str in args.qml_paths:
+            path = Path(path_str)
+            if path.is_file():
+                qml_files.append(str(path))
+            elif path.is_dir():
+                for root, _, files in os.walk(path):
+                    for file in files:
+                        if file.endswith(".qml"):
+                            qml_files.append(os.path.join(root, file))
+
+        if not qml_files:
+            print("No QML files found in the provided --qml-paths.", file=sys.stderr)
+            return 1
+
+        qml_linter_cmd = [
+            sys.executable, str(script_dir / "qml_linter.py")
+        ]
+
+        if run_in_chunks(qml_linter_cmd, qml_files):
+            has_failures = True
+
+    return 1 if has_failures else 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/run.py
+++ b/tools/run.py
@@ -93,6 +93,7 @@ def main() -> int:
                 args.clang_tidy,
                 "--experimental-custom-checks",
                 f"--config-file={config_file}",
+                "--warnings-as-errors=custom-qt-kde-lint-*",
                 "-p", str(args.build_dir)
             ]
 


### PR DESCRIPTION
1. The runner CLI `tools/run.py` supports inputs: `--build-dir`, `--clang-tidy`, `--cpp-paths`, and `--qml-paths`.
2. The composite action inputs are `build-directory`, `cpp-paths`, `qml-paths`, and `clang-tidy`. Example consumer usage:
```yaml
      - name: Run qt-kde-lint
        uses: arran4/qt-kde-lint@v1
        with:
          build-directory: build
          cpp-paths: src tests
          qml-paths: src
```
3. Consumers providing `--cpp-paths` must provide `--build-dir` which contains a valid `compile_commands.json` (exported by CMake).
4. Tests executed include argument parser tests in `tests/harness/test_run.py` and GitHub workflow CI tests across C++ and QML paths, covering all edge cases requested.
5. The `clang-tidy` version must explicitly be 23 or higher to support the `--experimental-custom-checks` feature, which the runner actively checks against.
6. Before cutting a v1 tag, ensure `action.yml` path references remain compatible once standard tags exist. The current setup is clean and relies on `github.action_path`.

---
*PR created automatically by Jules for task [12506306953847875998](https://jules.google.com/task/12506306953847875998) started by @arran4*